### PR TITLE
test(hvo): add comprehensive test suite and fix VM network adapter handling

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -331,12 +331,12 @@
         "description": "Returns detailed information about a specific virtual machine",
         "parameters": [
           {
-            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "required": true,
+            "name": "name"
           }
         ],
         "responses": {
@@ -383,12 +383,12 @@
         "description": "Updates configuration of an existing virtual machine. VM must be stopped. Returns 200 with unchanged=true if no changes were needed",
         "parameters": [
           {
-            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "required": true,
+            "name": "name"
           }
         ],
         "requestBody": {
@@ -476,12 +476,12 @@
         "description": "Deletes a virtual machine and its associated virtual hard disks",
         "parameters": [
           {
-            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "required": true,
+            "name": "name"
           }
         ],
         "responses": {
@@ -538,12 +538,12 @@
         "description": "Starts a virtual machine. If the VM is paused, it will be resumed",
         "parameters": [
           {
-            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "required": true,
+            "name": "name"
           }
         ],
         "responses": {
@@ -600,19 +600,19 @@
         "description": "Stops a virtual machine gracefully. Use force=true query parameter or body to force shutdown",
         "parameters": [
           {
-            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "required": true,
+            "name": "name"
           },
           {
-            "name": "force",
+            "in": "query",
             "schema": {
               "type": "boolean"
             },
-            "in": "query"
+            "name": "force"
           }
         ],
         "requestBody": {
@@ -703,19 +703,19 @@
         "description": "Restarts a virtual machine. Use force=true query parameter or body to force shutdown before restart",
         "parameters": [
           {
-            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "required": true,
+            "name": "name"
           },
           {
-            "name": "force",
+            "in": "query",
             "schema": {
               "type": "boolean"
             },
-            "in": "query"
+            "name": "force"
           }
         ],
         "requestBody": {
@@ -796,12 +796,12 @@
         "description": "Suspends (pauses) a running virtual machine",
         "parameters": [
           {
-            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "required": true,
+            "name": "name"
           }
         ],
         "responses": {
@@ -868,12 +868,12 @@
         "description": "Resumes a suspended virtual machine",
         "parameters": [
           {
-            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "required": true,
+            "name": "name"
           }
         ],
         "responses": {
@@ -1075,12 +1075,12 @@
         "description": "Returns detailed information about a specific virtual switch",
         "parameters": [
           {
-            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "required": true,
+            "name": "name"
           }
         ],
         "responses": {
@@ -1127,12 +1127,12 @@
         "description": "Updates the notes field of an existing virtual switch",
         "parameters": [
           {
-            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "required": true,
+            "name": "name"
           }
         ],
         "requestBody": {
@@ -1207,12 +1207,12 @@
         "description": "Deletes a virtual switch",
         "parameters": [
           {
-            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "required": true,
+            "name": "name"
           }
         ],
         "responses": {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -212,11 +212,11 @@ paths:
       summary: Get virtual machine details
       description: Returns detailed information about a specific virtual machine
       parameters:
-        - name: name
+        - in: path
           schema:
             type: string
-          in: path
           required: true
+          name: name
       responses:
         200:
           description: Virtual machine details
@@ -246,11 +246,11 @@ paths:
           Updates configuration of an existing virtual machine. VM must be stopped.
           Returns 200 with unchanged=true if no changes were needed
       parameters:
-        - name: name
+        - in: path
           schema:
             type: string
-          in: path
           required: true
+          name: name
       requestBody:
         content:
           application/json:
@@ -303,11 +303,11 @@ paths:
       summary: Delete a virtual machine
       description: Deletes a virtual machine and its associated virtual hard disks
       parameters:
-        - name: name
+        - in: path
           schema:
             type: string
-          in: path
           required: true
+          name: name
       responses:
         200:
           description: VM deleted successfully
@@ -341,11 +341,11 @@ paths:
       summary: Start a virtual machine
       description: Starts a virtual machine. If the VM is paused, it will be resumed
       parameters:
-        - name: name
+        - in: path
           schema:
             type: string
-          in: path
           required: true
+          name: name
       responses:
         200:
           description: VM started successfully
@@ -381,15 +381,15 @@ paths:
           Stops a virtual machine gracefully. Use force=true query parameter or body to
           force shutdown
       parameters:
-        - name: name
+        - in: path
           schema:
             type: string
-          in: path
           required: true
-        - name: force
+          name: name
+        - in: query
           schema:
             type: boolean
-          in: query
+          name: force
       requestBody:
         content:
           application/json:
@@ -445,15 +445,15 @@ paths:
           Restarts a virtual machine. Use force=true query parameter or body to force
           shutdown before restart
       parameters:
-        - name: name
+        - in: path
           schema:
             type: string
-          in: path
           required: true
-        - name: force
+          name: name
+        - in: query
           schema:
             type: boolean
-          in: query
+          name: force
       requestBody:
         content:
           application/json:
@@ -501,11 +501,11 @@ paths:
       summary: Suspend a virtual machine
       description: Suspends (pauses) a running virtual machine
       parameters:
-        - name: name
+        - in: path
           schema:
             type: string
-          in: path
           required: true
+          name: name
       responses:
         200:
           description: VM suspended successfully
@@ -545,11 +545,11 @@ paths:
       summary: Resume a virtual machine
       description: Resumes a suspended virtual machine
       parameters:
-        - name: name
+        - in: path
           schema:
             type: string
-          in: path
           required: true
+          name: name
       responses:
         200:
           description: VM resumed successfully
@@ -676,11 +676,11 @@ paths:
       summary: Get virtual switch details
       description: Returns detailed information about a specific virtual switch
       parameters:
-        - name: name
+        - in: path
           schema:
             type: string
-          in: path
           required: true
+          name: name
       responses:
         200:
           description: Virtual switch details
@@ -708,11 +708,11 @@ paths:
       summary: Update a virtual switch
       description: Updates the notes field of an existing virtual switch
       parameters:
-        - name: name
+        - in: path
           schema:
             type: string
-          in: path
           required: true
+          name: name
       requestBody:
         content:
           application/json:
@@ -757,11 +757,11 @@ paths:
       summary: Delete a virtual switch
       description: Deletes a virtual switch
       parameters:
-        - name: name
+        - in: path
           schema:
             type: string
-          in: path
           required: true
+          name: name
       responses:
         200:
           description: Switch deleted successfully

--- a/src/modules/HvoVm/HvoVm.psm1
+++ b/src/modules/HvoVm/HvoVm.psm1
@@ -106,8 +106,15 @@ function Set-HvoVm {
         # SWITCH — update only if different
         #
         if ($PSBoundParameters.ContainsKey("SwitchName")) {
-            $currentNic = Get-VMNetworkAdapter -VMName $Name -ErrorAction SilentlyContinue
-            $currentSwitch = $currentNic?.SwitchName
+            $currentNics = Get-VMNetworkAdapter -VMName $Name -ErrorAction SilentlyContinue
+            # Get-VMNetworkAdapter returns an array, take the first adapter
+            $currentSwitch = $null
+            if ($currentNics) {
+                $firstNic = if ($currentNics -is [Array]) { $currentNics[0] } else { $currentNics }
+                if ($firstNic) {
+                    $currentSwitch = $firstNic.SwitchName
+                }
+            }
 
             if ($currentSwitch -ne $SwitchName) {
                 Get-VMNetworkAdapter -VMName $Name |
@@ -244,7 +251,7 @@ function Start-HvoVm {
             return $null
         }
 
-        Write-Host "Start-HvoVm error: $($_ | Out-String)" -ForegroundColor Red
+        # Propagate the exception without display - the caller will handle the error
         throw
     }
 }
@@ -276,7 +283,7 @@ function Stop-HvoVm {
                 Stop-VM -Name $Name -Force -ErrorAction Stop
             }
             else {
-                # Vérifier la présence et l'activation du service d'intégration d'arrêt
+                # Check the presence and activation of the shutdown integration service
                 $shutdownService = Get-VMIntegrationService -VMName $Name -Name "Shutdown" -ErrorAction SilentlyContinue
 
                 if (-not $shutdownService) {
@@ -304,7 +311,7 @@ function Stop-HvoVm {
             return $null
         }
 
-        Write-Host "Stop-HvoVm error: $($_ | Out-String)" -ForegroundColor Red
+        # Propagate the exception without display - the caller will handle the error
         throw
     }
 }
@@ -337,15 +344,15 @@ function Restart-HvoVm {
                 Restart-VM -Name $Name -Force -ErrorAction Stop
             }
             else {
-                # Vérifier la présence et l'activation du service d'intégration d'arrêt
+                # Check the presence and activation of the shutdown integration service
                 $shutdownService = Get-VMIntegrationService -VMName $Name -Name "Shutdown" -ErrorAction SilentlyContinue
 
                 if (-not $shutdownService) {
-                    throw "SHUTDOWN_SERVICE_NOT_AVAILABLE: Le service d'intégration d'arrêt (Shutdown) n'est pas disponible pour la VM '$Name'. Utilisez le paramètre 'force' pour un redémarrage forcé."
+                    throw "SHUTDOWN_SERVICE_NOT_AVAILABLE: The shutdown integration service is not available for VM '$Name'. Use the 'force' parameter for a forced restart."
                 }
 
                 if (-not $shutdownService.Enabled) {
-                    throw "SHUTDOWN_SERVICE_NOT_ENABLED: Le service d'intégration d'arrêt (Shutdown) n'est pas activé pour la VM '$Name'. Utilisez le paramètre 'force' pour un redémarrage forcé."
+                    throw "SHUTDOWN_SERVICE_NOT_ENABLED: The shutdown integration service is not enabled for VM '$Name'. Use the 'force' parameter for a forced restart."
                 }
 
                 Restart-VM -Name $Name -ErrorAction Stop
@@ -364,7 +371,7 @@ function Restart-HvoVm {
             return $null
         }
 
-        Write-Host "Restart-HvoVm error: $($_ | Out-String)" -ForegroundColor Red
+        # Propagate the exception without display - the caller will handle the error
         throw
     }
 }
@@ -407,7 +414,7 @@ function Suspend-HvoVm {
             return $null
         }
 
-        Write-Host "Suspend-HvoVm error: $($_ | Out-String)" -ForegroundColor Red
+        # Propagate the exception without display - the caller will handle the error
         throw
     }
 }
@@ -453,7 +460,7 @@ function Resume-HvoVm {
             return $null
         }
 
-        Write-Host "Resume-HvoVm error: $($_ | Out-String)" -ForegroundColor Red
+        # Propagate the exception without display - the caller will handle the error
         throw
     }
 }
@@ -508,7 +515,7 @@ function Remove-HvoVm {
             return $false
         }
 
-        Write-Host "Remove-HvoVm error: $($_ | Out-String)" -ForegroundColor Red
+        # Propagate the exception without display - the caller will handle the error
         throw
     }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,173 @@
+# Tests
+
+This directory contains unit tests for the project.
+
+## Structure
+
+```text
+tests/
+├── unit/                  # Unit tests for PowerShell modules
+│   ├── HvoVm.Tests.ps1
+│   ├── HvoSwitch.Tests.ps1
+│   └── utils.Tests.ps1
+├── run-tests.ps1          # Test execution script
+└── analyze-coverage.ps1   # Coverage analysis script
+```
+
+## Prerequisites
+
+- PowerShell 7
+- Pester module (version 5.x recommended)
+
+Install Pester:
+
+```powershell
+Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck
+```
+
+## Running Tests
+
+### All unit tests
+
+```powershell
+.\tests\run-tests.ps1
+```
+
+### Unit tests only
+
+```powershell
+Invoke-Pester -Path tests/unit/
+```
+
+### With code coverage
+
+```powershell
+.\tests\run-tests.ps1 -Coverage
+```
+
+After running tests with coverage, analyze the results:
+
+```powershell
+.\tests\analyze-coverage.ps1
+```
+
+Or using Pester directly:
+
+```powershell
+$config = New-PesterConfiguration
+$config.Run.Path = 'tests/unit/'
+$config.CodeCoverage.Enabled = $true
+$config.CodeCoverage.Path = @(
+    'src/modules/**/*.psm1',
+    'src/utils.psm1'
+)
+$config.CodeCoverage.OutputFormat = 'CoverageGutters'
+Invoke-Pester -Configuration $config
+```
+
+## Tested Functions
+
+### HvoVm Module
+
+- `New-HvoVm` - Create a new virtual machine
+- `Get-HvoVm` - Get a single VM by name
+- `Get-HvoVms` - Get all VMs
+- `Set-HvoVm` - Update VM configuration (memory, vCPU, switch, ISO)
+- `Start-HvoVm` - Start a VM
+- `Stop-HvoVm` - Stop a VM
+- `Restart-HvoVm` - Restart a VM
+- `Suspend-HvoVm` - Suspend a VM
+- `Resume-HvoVm` - Resume a suspended VM
+- `Remove-HvoVm` - Remove a VM
+
+### HvoSwitch Module
+
+- `New-HvoSwitch` - Create a new virtual switch
+- `Get-HvoSwitch` - Get a single switch by name
+- `Get-HvoSwitches` - Get all switches
+- `Set-HvoSwitch` - Update switch configuration (notes)
+- `Remove-HvoSwitch` - Remove a switch
+
+### Utils Module
+
+- `Get-HvoJsonBody` - Parse JSON from WebEvent request body
+
+## Writing Tests
+
+### Pester Test Structure
+
+```powershell
+Describe "Get-HvoVm" {
+    BeforeAll {
+        $modulePath = Join-Path $PSScriptRoot "../../src/modules/HvoVm/HvoVm.psd1"
+        Import-Module $modulePath -Force
+    }
+
+    InModuleScope HvoVm {
+        Context "When the VM exists" {
+            It "Should return the VM details" {
+                # Arrange
+                $vmName = "test-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+
+                # Act
+                $result = Get-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Name | Should -Be $vmName
+            }
+        }
+    }
+}
+```
+
+## Code Coverage
+
+### Current Coverage Status
+
+Run the coverage analysis script to see detailed coverage:
+
+```powershell
+.\tests\analyze-coverage.ps1
+```
+
+Current coverage (as of last test run):
+
+- **Overall**: 93.9% (279/297 instructions)
+- **HvoSwitch module**: 100% (38/38 instructions)
+- **HvoVm module**: 92.8% (233/251 instructions)
+- **Utils module**: 100% (8/8 instructions)
+
+### Coverage by Function Type
+
+**Critical functions** (VM lifecycle):
+
+- `New-HvoVm`: 100%
+- `Start-HvoVm`: 96.8%
+- `Remove-HvoVm`: 95.8%
+- `Suspend-HvoVm`: 94.7%
+- `Stop-HvoVm`: 92.3%
+- `Restart-HvoVm`: 92%
+- `Resume-HvoVm`: 90.5%
+
+**Business logic modules**: 96.4% average (HvoVm + HvoSwitch)
+
+**Utility code**: 100%
+
+### Coverage Goals
+
+Target coverage levels:
+
+- **Critical code** (VM creation/deletion, lifecycle actions): > 90% (currently 94.6%) ✓
+- **Business logic** (HvoVm, HvoSwitch modules): > 80% (currently 96.4%) ✓
+- **Utility code**: > 60% (currently 100%) ✓
+- **Overall**: > 75% (currently 93.9%) ✓
+
+## CI/CD
+
+Tests are automatically executed in GitHub Actions on each Pull Request.

--- a/tests/analyze-coverage.ps1
+++ b/tests/analyze-coverage.ps1
@@ -1,0 +1,174 @@
+# Analyze code coverage from coverage.xml
+# Usage: .\tests\analyze-coverage.ps1
+
+param(
+    [string]$CoverageFile = "coverage.xml"
+)
+
+if (-not (Test-Path $CoverageFile)) {
+    Write-Error "Coverage file not found: $CoverageFile"
+    exit 1
+}
+
+[xml]$coverage = Get-Content $CoverageFile
+
+Write-Host "`n=== Coverage by Module ===" -ForegroundColor Cyan
+$packages = $coverage.report.package
+foreach ($pkg in $packages) {
+    $counter = $pkg.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+    if ($counter) {
+        $missed = [int]$counter.missed
+        $covered = [int]$counter.covered
+        $total = $missed + $covered
+        if ($total -gt 0) {
+            $pct = [math]::Round(($covered / $total) * 100, 1)
+            $pkgName = $pkg.name -replace '.*/([^/]+)$', '$1'
+            Write-Host "$pkgName : $pct% ($covered/$total)"
+        }
+    }
+}
+
+Write-Host "`n=== Critical Functions (VM Lifecycle) ===" -ForegroundColor Cyan
+$criticalFunctions = @('New-HvoVm', 'Remove-HvoVm', 'Start-HvoVm', 'Stop-HvoVm', 'Restart-HvoVm', 'Suspend-HvoVm', 'Resume-HvoVm')
+$methods = $coverage.SelectNodes('//method')
+foreach ($method in $methods) {
+    $methodName = $method.name
+    if ($criticalFunctions -contains $methodName) {
+        $counter = $method.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+        if ($counter) {
+            $missed = [int]$counter.missed
+            $covered = [int]$counter.covered
+            $total = $missed + $covered
+            if ($total -gt 0) {
+                $pct = [math]::Round(($covered / $total) * 100, 1)
+                $status = if ($pct -ge 90) { "✓" } else { "✗" }
+                Write-Host "  $status $methodName : $pct% ($covered/$total)" -ForegroundColor $(if ($pct -ge 90) { "Green" } else { "Yellow" })
+            }
+        }
+    }
+}
+
+Write-Host "`n=== Business Logic Modules ===" -ForegroundColor Cyan
+$businessModules = @('HvoVm', 'HvoSwitch')
+foreach ($pkg in $packages) {
+    $pkgName = $pkg.name -replace '.*/([^/]+)$', '$1'
+    if ($businessModules -contains $pkgName) {
+        $counter = $pkg.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+        if ($counter) {
+            $missed = [int]$counter.missed
+            $covered = [int]$counter.covered
+            $total = $missed + $covered
+            if ($total -gt 0) {
+                $pct = [math]::Round(($covered / $total) * 100, 1)
+                $status = if ($pct -ge 80) { "✓" } else { "✗" }
+                Write-Host "$status $pkgName : $pct% ($covered/$total)" -ForegroundColor $(if ($pct -ge 80) { "Green" } else { "Yellow" })
+            }
+        }
+    }
+}
+
+Write-Host "`n=== Utility Code ===" -ForegroundColor Cyan
+foreach ($pkg in $packages) {
+    $pkgName = $pkg.name -replace '.*/([^/]+)$', '$1'
+    if ($pkgName -eq 'src' -or $pkgName -eq 'utils') {
+        $counter = $pkg.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+        if ($counter) {
+            $missed = [int]$counter.missed
+            $covered = [int]$counter.covered
+            $total = $missed + $covered
+            if ($total -gt 0) {
+                $pct = [math]::Round(($covered / $total) * 100, 1)
+                $status = if ($pct -ge 60) { "✓" } else { "✗" }
+                Write-Host "$status $pkgName : $pct% ($covered/$total)" -ForegroundColor $(if ($pct -ge 60) { "Green" } else { "Yellow" })
+            }
+        }
+    }
+}
+
+Write-Host "`n=== Overall Coverage ===" -ForegroundColor Cyan
+$overallCounter = $coverage.report.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+if ($overallCounter) {
+    $missed = [int]$overallCounter.missed
+    $covered = [int]$overallCounter.covered
+    $total = $missed + $covered
+    if ($total -gt 0) {
+        $pct = [math]::Round(($covered / $total) * 100, 1)
+        $status = if ($pct -ge 75) { "✓" } else { "✗" }
+        Write-Host "$status Overall : $pct% ($covered/$total)" -ForegroundColor $(if ($pct -ge 75) { "Green" } else { "Yellow" })
+    }
+}
+
+Write-Host "`n=== Coverage Goals Check ===" -ForegroundColor Cyan
+Write-Host "Critical code (>90%): " -NoNewline
+$criticalCoverage = $coverage.SelectNodes('//method') | Where-Object {
+    $criticalFunctions -contains $_.name
+} | ForEach-Object {
+    $counter = $_.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+    if ($counter) {
+        $missed = [int]$counter.missed
+        $covered = [int]$counter.covered
+        $total = $missed + $covered
+        if ($total -gt 0) { ($covered / $total) * 100 } else { 0 }
+    }
+} | Measure-Object -Average
+
+if ($criticalCoverage.Average -ge 90) {
+    Write-Host "✓ PASSED ($([math]::Round($criticalCoverage.Average, 1))%)" -ForegroundColor Green
+} else {
+    Write-Host "✗ FAILED ($([math]::Round($criticalCoverage.Average, 1))%)" -ForegroundColor Red
+}
+
+Write-Host "Business logic (>80%): " -NoNewline
+$businessCoverage = $packages | Where-Object {
+    $pkgName = $_.name -replace '.*/([^/]+)$', '$1'
+    $businessModules -contains $pkgName
+} | ForEach-Object {
+    $counter = $_.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+    if ($counter) {
+        $missed = [int]$counter.missed
+        $covered = [int]$counter.covered
+        $total = $missed + $covered
+        if ($total -gt 0) { ($covered / $total) * 100 } else { 0 }
+    }
+} | Measure-Object -Average
+
+if ($businessCoverage.Average -ge 80) {
+    Write-Host "✓ PASSED ($([math]::Round($businessCoverage.Average, 1))%)" -ForegroundColor Green
+} else {
+    Write-Host "✗ FAILED ($([math]::Round($businessCoverage.Average, 1))%)" -ForegroundColor Red
+}
+
+Write-Host "Utility code (>60%): " -NoNewline
+$utilityCoverage = $packages | Where-Object {
+    $pkgName = $_.name -replace '.*/([^/]+)$', '$1'
+    $pkgName -eq 'src' -or $pkgName -eq 'utils'
+} | ForEach-Object {
+    $counter = $_.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+    if ($counter) {
+        $missed = [int]$counter.missed
+        $covered = [int]$counter.covered
+        $total = $missed + $covered
+        if ($total -gt 0) { ($covered / $total) * 100 } else { 0 }
+    }
+} | Measure-Object -Average
+
+if ($utilityCoverage.Average -ge 60) {
+    Write-Host "✓ PASSED ($([math]::Round($utilityCoverage.Average, 1))%)" -ForegroundColor Green
+} else {
+    Write-Host "✗ FAILED ($([math]::Round($utilityCoverage.Average, 1))%)" -ForegroundColor Red
+}
+
+Write-Host "Overall (>75%): " -NoNewline
+if ($overallCounter) {
+    $missed = [int]$overallCounter.missed
+    $covered = [int]$overallCounter.covered
+    $total = $missed + $covered
+    if ($total -gt 0) {
+        $pct = ($covered / $total) * 100
+        if ($pct -ge 75) {
+            Write-Host "✓ PASSED ($([math]::Round($pct, 1))%)" -ForegroundColor Green
+        } else {
+            Write-Host "✗ FAILED ($([math]::Round($pct, 1))%)" -ForegroundColor Red
+        }
+    }
+}

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -1,0 +1,79 @@
+# Unit test execution script
+# Usage: .\tests\run-tests.ps1 [-Unit] [-Integration] [-Coverage]
+
+param(
+    [switch]$Unit,
+    [switch]$Integration,
+    [switch]$Coverage,
+    [switch]$All
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Check if Pester is installed
+$pesterModule = Get-Module -ListAvailable -Name 'Pester' -ErrorAction SilentlyContinue
+if (-not $pesterModule) {
+    Write-Host "Pester is not installed. Installing..." -ForegroundColor Yellow
+    Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
+    Import-Module Pester -Force
+} else {
+    Write-Host "Pester version $($pesterModule.Version) detected" -ForegroundColor Green
+    Import-Module Pester -Force
+}
+
+# Determine which tests to run
+$runUnit = $Unit -or $All -or (-not $Integration)
+$runIntegration = $Integration -or $All
+
+$unitPath = Join-Path $PSScriptRoot "unit"
+$integrationPath = Join-Path $PSScriptRoot "integration"
+
+$allPassed = $true
+
+# Run unit tests
+if ($runUnit) {
+    Write-Host "`n=== Unit Tests ===" -ForegroundColor Cyan
+    $unitConfig = New-PesterConfiguration
+    $unitConfig.Run.Path = $unitPath
+    $unitConfig.Output.Verbosity = 'Detailed'
+
+    if ($Coverage) {
+        $unitConfig.CodeCoverage.Enabled = $true
+        $unitConfig.CodeCoverage.Path = @(
+            "$PSScriptRoot/../src/modules/**/*.psm1",
+            "$PSScriptRoot/../src/utils.psm1"
+        )
+        $unitConfig.CodeCoverage.OutputFormat = 'CoverageGutters'
+        $unitConfig.CodeCoverage.OutputPath = "$PSScriptRoot/../coverage.xml"
+    }
+
+    $unitResults = Invoke-Pester -Configuration $unitConfig
+
+    if ($unitResults.FailedCount -gt 0) {
+        $allPassed = $false
+    }
+}
+
+# Run integration tests
+if ($runIntegration) {
+    Write-Host "`n=== Integration Tests ===" -ForegroundColor Cyan
+    $integrationConfig = New-PesterConfiguration
+    $integrationConfig.Run.Path = $integrationPath
+    $integrationConfig.Output.Verbosity = 'Detailed'
+
+    $integrationResults = Invoke-Pester -Configuration $integrationConfig
+
+    if ($integrationResults.FailedCount -gt 0) {
+        $allPassed = $false
+    }
+}
+
+# Summary
+Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+if ($allPassed) {
+    Write-Host "All tests passed!" -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "Some tests failed." -ForegroundColor Red
+    exit 1
+}

--- a/tests/unit/HvoSwitch.Tests.ps1
+++ b/tests/unit/HvoSwitch.Tests.ps1
@@ -1,0 +1,368 @@
+# Unit tests for the HvoSwitch module
+# Uses InModuleScope to test within the module context and allow mocks to work
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot "../../src/modules/HvoSwitch/HvoSwitch.psd1"
+    Import-Module $modulePath -Force
+}
+
+InModuleScope HvoSwitch {
+    Describe "New-HvoSwitch" {
+        Context "When the switch already exists" {
+            It "Should return an object with Exists = true" {
+                # Arrange
+                $switchName = "existing-switch"
+                $mockSwitch = [PSCustomObject]@{
+                    Name = $switchName
+                }
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                Mock New-VMSwitch -MockWith { }
+
+                # Act
+                $result = New-HvoSwitch -Name $switchName -Type "Internal"
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Exists | Should -Be $true
+                $result.Name | Should -Be $switchName
+                Should -Invoke Get-VMSwitch -Exactly -Times 1 -ParameterFilter { $Name -eq $switchName }
+                Should -Not -Invoke New-VMSwitch
+            }
+        }
+
+        Context "When the switch does not exist" {
+            It "Should create an Internal type switch" {
+                # Arrange
+                $switchName = "new-internal-switch"
+                $mockSwitch = [PSCustomObject]@{
+                    Name = $switchName
+                }
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+                Mock New-VMSwitch -ParameterFilter {
+                    $Name -eq $switchName -and $SwitchType -eq "Internal"
+                } -MockWith { return $mockSwitch }
+
+                # Act
+                $result = New-HvoSwitch -Name $switchName -Type "Internal"
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Exists | Should -Be $false
+                $result.Name | Should -Be $switchName
+                Should -Invoke New-VMSwitch -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $switchName -and $SwitchType -eq "Internal"
+                }
+            }
+
+            It "Should create a Private type switch" {
+                # Arrange
+                $switchName = "new-private-switch"
+                $mockSwitch = [PSCustomObject]@{
+                    Name = $switchName
+                }
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+                Mock New-VMSwitch -ParameterFilter {
+                    $Name -eq $switchName -and $SwitchType -eq "Private"
+                } -MockWith { return $mockSwitch }
+
+                # Act
+                $result = New-HvoSwitch -Name $switchName -Type "Private"
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Exists | Should -Be $false
+                $result.Name | Should -Be $switchName
+                Should -Invoke New-VMSwitch -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $switchName -and $SwitchType -eq "Private"
+                }
+            }
+
+            It "Should create an External type switch with NetAdapterName" {
+                # Arrange
+                $switchName = "new-external-switch"
+                $netAdapterName = "Ethernet"
+                $mockSwitch = [PSCustomObject]@{
+                    Name = $switchName
+                }
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+                Mock New-VMSwitch -ParameterFilter {
+                    $Name -eq $switchName -and
+                    $NetAdapterName -eq $netAdapterName -and
+                    $AllowManagementOS -eq $true
+                } -MockWith { return $mockSwitch }
+
+                # Act
+                $result = New-HvoSwitch -Name $switchName -Type "External" -NetAdapterName $netAdapterName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Exists | Should -Be $false
+                $result.Name | Should -Be $switchName
+                Should -Invoke New-VMSwitch -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $switchName -and
+                    $NetAdapterName -eq $netAdapterName -and
+                    $AllowManagementOS -eq $true
+                }
+            }
+
+            It "Should throw an exception if External is created without NetAdapterName" {
+                # Arrange
+                $switchName = "external-switch-no-adapter"
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+
+                # Act & Assert
+                { New-HvoSwitch -Name $switchName -Type "External" } | Should -Throw "External switch requires -NetAdapterName"
+            }
+
+            It "Should apply notes if provided" {
+                # Arrange
+                $switchName = "switch-with-notes"
+                $notes = "Test switch notes"
+                $mockSwitch = [PSCustomObject]@{
+                    Name = $switchName
+                }
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+                Mock New-VMSwitch -MockWith { return $mockSwitch }
+                Mock Set-VMSwitch -MockWith { }
+
+                # Act
+                $result = New-HvoSwitch -Name $switchName -Type "Internal" -Notes $notes
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                Should -Invoke Set-VMSwitch -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $switchName -and $Notes -eq $notes
+                }
+            }
+        }
+    }
+
+    Describe "Get-HvoSwitch" {
+        Context "When the switch exists" {
+            It "Should return the switch" {
+                # Arrange
+                $switchName = "test-switch"
+                $mockSwitch = [PSCustomObject]@{
+                    Name = $switchName
+                    SwitchType = "Internal"
+                }
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+
+                # Act
+                $result = Get-HvoSwitch -Name $switchName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Name | Should -Be $switchName
+                Should -Invoke Get-VMSwitch -Exactly -Times 1 -ParameterFilter { $Name -eq $switchName }
+            }
+        }
+
+        Context "When the switch does not exist" {
+            It "Should return null" {
+                # Arrange
+                $switchName = "non-existent-switch"
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+
+                # Act
+                $result = Get-HvoSwitch -Name $switchName
+
+                # Assert
+                $result | Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Describe "Get-HvoSwitches" {
+        It "Should return the list of all switches" {
+            # Arrange
+            $mockSwitches = @(
+                [PSCustomObject]@{
+                    Name = "switch1"
+                    SwitchType = "Internal"
+                    Notes = "Notes 1"
+                },
+                [PSCustomObject]@{
+                    Name = "switch2"
+                    SwitchType = "External"
+                    Notes = "Notes 2"
+                }
+            )
+
+            Mock Get-VMSwitch -MockWith { return $mockSwitches }
+
+            # Act
+            $result = Get-HvoSwitches
+
+            # Assert
+            $result | Should -Not -BeNullOrEmpty
+            $result.Count | Should -Be 2
+            $result[0].Name | Should -Be "switch1"
+            $result[1].Name | Should -Be "switch2"
+            Should -Invoke Get-VMSwitch -Exactly -Times 1
+        }
+
+        It "Should return an empty array if there are no switches" {
+            # Arrange
+            Mock Get-VMSwitch -MockWith { return @() }
+
+            # Act
+            $result = Get-HvoSwitches
+
+            # Assert
+            # Select-Object on an empty array may return $null, so we accept both cases
+            if ($null -eq $result) {
+                $result = @()
+            }
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Describe "Set-HvoSwitch" {
+        Context "When the switch does not exist" {
+            It "Should return Updated = false with an error" {
+                # Arrange
+                $switchName = "non-existent-switch"
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+                Mock Set-VMSwitch -MockWith { }
+
+                # Act
+                $result = Set-HvoSwitch -Name $switchName -Notes "New notes"
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Updated | Should -Be $false
+                $result.Error | Should -Be "Switch not found"
+                Should -Not -Invoke Set-VMSwitch
+            }
+        }
+
+        Context "When the switch exists" {
+            It "Should update notes" {
+                # Arrange
+                $switchName = "existing-switch"
+                $newNotes = "Updated notes"
+                $mockSwitch = [PSCustomObject]@{
+                    Name = $switchName
+                }
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                Mock Set-VMSwitch -MockWith { }
+
+                # Act
+                $result = Set-HvoSwitch -Name $switchName -Notes $newNotes
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Updated | Should -Be $true
+                $result.Name | Should -Be $switchName
+                Should -Invoke Set-VMSwitch -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $switchName -and $Notes -eq $newNotes
+                }
+            }
+
+            It "Should return Updated = true even without modification if the switch exists" {
+                # Arrange
+                $switchName = "existing-switch"
+                $mockSwitch = [PSCustomObject]@{
+                    Name = $switchName
+                }
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                Mock Set-VMSwitch -MockWith { }
+
+                # Act
+                $result = Set-HvoSwitch -Name $switchName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Updated | Should -Be $true
+                $result.Name | Should -Be $switchName
+                Should -Not -Invoke Set-VMSwitch
+            }
+        }
+
+        Context "When an error occurs" {
+            It "Should propagate the exception" {
+                # Arrange
+                $switchName = "switch-with-error"
+                $mockSwitch = [PSCustomObject]@{
+                    Name = $switchName
+                }
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                Mock Set-VMSwitch -MockWith { throw "Test error" }
+
+                # Act & Assert
+                { Set-HvoSwitch -Name $switchName -Notes "Test" } | Should -Throw
+            }
+        }
+    }
+
+    Describe "Remove-HvoSwitch" {
+        Context "When the switch does not exist" {
+            It "Should return false" {
+                # Arrange
+                $switchName = "non-existent-switch"
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+                Mock Remove-VMSwitch -MockWith { }
+
+                # Act
+                $result = Remove-HvoSwitch -Name $switchName
+
+                # Assert
+                $result | Should -Be $false
+                Should -Not -Invoke Remove-VMSwitch
+            }
+        }
+
+        Context "When the switch exists" {
+            It "Should remove the switch" {
+                # Arrange
+                $switchName = "existing-switch"
+                $mockSwitch = [PSCustomObject]@{
+                    Name = $switchName
+                }
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                Mock Remove-VMSwitch -MockWith { }
+
+                # Act
+                $result = Remove-HvoSwitch -Name $switchName
+
+                # Assert
+                $result | Should -Be $true
+                Should -Invoke Remove-VMSwitch -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $switchName -and $Force -eq $true
+                }
+            }
+
+            It "Should return false if deletion fails" {
+                # Arrange
+                $switchName = "switch-with-error"
+                $mockSwitch = [PSCustomObject]@{
+                    Name = $switchName
+                }
+
+                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                Mock Remove-VMSwitch -MockWith { throw "Cannot remove switch" }
+
+                # Act
+                $result = Remove-HvoSwitch -Name $switchName
+
+                # Assert
+                $result | Should -Be $false
+            }
+        }
+    }
+}

--- a/tests/unit/HvoVm.Tests.ps1
+++ b/tests/unit/HvoVm.Tests.ps1
@@ -1,0 +1,1219 @@
+# Unit tests for the HvoVm module
+# Uses InModuleScope to test within the module context and allow mocks to work
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot "../../src/modules/HvoVm/HvoVm.psd1"
+    Import-Module $modulePath -Force
+}
+
+InModuleScope HvoVm {
+    Describe "New-HvoVm" {
+        Context "When the VM already exists" {
+            It "Should return an object with Exists = true" {
+                # Arrange
+                $vmName = "test-vm-existing"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock New-VM -MockWith { }
+
+                # Act
+                $result = New-HvoVm -Name $vmName -MemoryMB 1024 -Vcpu 2 -DiskPath "C:\VMs" -DiskGB 20 -SwitchName "test-switch"
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Exists | Should -Be $true
+                $result.Name | Should -Be $vmName
+                Should -Invoke Get-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+                Should -Not -Invoke New-VM
+            }
+        }
+
+        Context "When the VM does not exist" {
+            It "Should create a new VM with the provided parameters" {
+                # Arrange
+                $vmName = "test-vm-new"
+                $diskPath = "C:\TestVMs"
+                $vhdPath = Join-Path $diskPath "$vmName.vhdx"
+                $switchName = "test-switch"
+
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                }
+
+                Mock Get-VM -MockWith { return $null }
+                Mock Test-Path -ParameterFilter { $Path -eq $diskPath } -MockWith { return $false }
+                Mock New-Item -MockWith { return [PSCustomObject]@{ FullName = $diskPath } }
+                Mock Test-Path -ParameterFilter { $Path -eq $vhdPath } -MockWith { return $false }
+                Mock New-VHD -MockWith { return [PSCustomObject]@{ Path = $vhdPath } }
+                Mock New-VM -MockWith { return $mockVm }
+                Mock Set-VMProcessor -MockWith { }
+
+                # Act
+                $result = New-HvoVm -Name $vmName -MemoryMB 2048 -Vcpu 4 -DiskPath $diskPath -DiskGB 40 -SwitchName $switchName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Exists | Should -Be $false
+                $result.Name | Should -Be $vmName
+                Should -Invoke New-VM -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $vmName -and
+                    $MemoryStartupBytes -eq (2048 * 1MB) -and
+                    $Generation -eq 2 -and
+                    $VHDPath -eq $vhdPath -and
+                    $SwitchName -eq $switchName
+                }
+                Should -Invoke Set-VMProcessor -Exactly -Times 1 -ParameterFilter {
+                    $VMName -eq $vmName -and $Count -eq 4
+                }
+            }
+
+            It "Should create the disk directory if it does not exist" {
+                # Arrange
+                $vmName = "test-vm-new"
+                $diskPath = "C:\TestVMs"
+
+                Mock Get-VM -MockWith { return $null }
+                Mock Test-Path -ParameterFilter { $Path -eq $diskPath } -MockWith { return $false }
+                Mock New-Item -MockWith { return [PSCustomObject]@{ FullName = $diskPath } }
+                Mock Test-Path -ParameterFilter { $Path -like "*.vhdx" } -MockWith { return $false }
+                Mock New-VHD -MockWith { return [PSCustomObject]@{ Path = "test.vhdx" } }
+                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName } }
+                Mock Set-VMProcessor -MockWith { }
+
+                # Act
+                New-HvoVm -Name $vmName -MemoryMB 1024 -Vcpu 2 -DiskPath $diskPath -DiskGB 20 -SwitchName "test-switch" | Out-Null
+
+                # Assert
+                Should -Invoke New-Item -Exactly -Times 1 -ParameterFilter {
+                    $ItemType -eq "Directory" -and $Path -eq $diskPath
+                }
+            }
+
+            It "Should create the VHD if it does not exist" {
+                # Arrange
+                $vmName = "test-vm-new"
+                $diskPath = "C:\TestVMs"
+                $vhdPath = Join-Path $diskPath "$vmName.vhdx"
+
+                Mock Get-VM -MockWith { return $null }
+                Mock Test-Path -ParameterFilter { $Path -eq $diskPath } -MockWith { return $true }
+                Mock Test-Path -ParameterFilter { $Path -eq $vhdPath } -MockWith { return $false }
+                Mock New-VHD -MockWith { return [PSCustomObject]@{ Path = $vhdPath } }
+                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName } }
+                Mock Set-VMProcessor -MockWith { }
+
+                # Act
+                New-HvoVm -Name $vmName -MemoryMB 1024 -Vcpu 2 -DiskPath $diskPath -DiskGB 20 -SwitchName "test-switch" | Out-Null
+
+                # Assert
+                Should -Invoke New-VHD -Exactly -Times 1 -ParameterFilter {
+                    $Path -eq $vhdPath -and $SizeBytes -eq (20 * 1GB) -and $Dynamic -eq $true
+                }
+            }
+
+            It "Should add a DVD drive if IsoPath is provided" {
+                # Arrange
+                $vmName = "test-vm-new"
+                $isoPath = "C:\ISOs\test.iso"
+
+                Mock Get-VM -MockWith { return $null }
+                Mock Test-Path -ParameterFilter { $Path -ne $isoPath } -MockWith { return $true }
+                Mock Test-Path -ParameterFilter { $Path -eq $isoPath } -MockWith { return $true }
+                Mock New-VHD -MockWith { return [PSCustomObject]@{ Path = "test.vhdx" } }
+                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName } }
+                Mock Set-VMProcessor -MockWith { }
+                Mock Add-VMDvdDrive -MockWith { }
+
+                # Act
+                New-HvoVm -Name $vmName -MemoryMB 1024 -Vcpu 2 -DiskPath "C:\VMs" -DiskGB 20 -SwitchName "test-switch" -IsoPath $isoPath | Out-Null
+
+                # Assert
+                Should -Invoke Add-VMDvdDrive -Exactly -Times 1 -ParameterFilter {
+                    $VMName -eq $vmName -and $Path -eq $isoPath
+                }
+            }
+
+            It "Should throw an exception if IsoPath does not exist" {
+                # Arrange
+                $vmName = "test-vm-new"
+                $isoPath = "C:\ISOs\nonexistent.iso"
+
+                Mock Get-VM -MockWith { return $null }
+                Mock Test-Path -ParameterFilter { $Path -ne $isoPath } -MockWith { return $true }
+                Mock Test-Path -ParameterFilter { $Path -eq $isoPath } -MockWith { return $false }
+                Mock New-VHD -MockWith { return [PSCustomObject]@{ Path = "test.vhdx" } }
+                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName } }
+                Mock Set-VMProcessor -MockWith { }
+
+                # Act & Assert
+                { New-HvoVm -Name $vmName -MemoryMB 1024 -Vcpu 2 -DiskPath "C:\VMs" -DiskGB 20 -SwitchName "test-switch" -IsoPath $isoPath } | Should -Throw
+            }
+        }
+    }
+
+    Describe "Get-HvoVm" {
+        Context "When the VM exists" {
+            It "Should return the VM details" {
+                # Arrange
+                $vmName = "test-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                    CPUUsage = 50
+                    MemoryAssigned = 1GB
+                    Uptime = New-TimeSpan -Days 1
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+
+                # Act
+                $result = Get-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Name | Should -Be $vmName
+                $result.State | Should -Be "Running"
+                $result.CPUUsage | Should -Be 50
+                $result.MemoryAssigned | Should -Be 1GB
+                Should -Invoke Get-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+            }
+        }
+
+        Context "When the VM does not exist" {
+            It "Should return null" {
+                # Arrange
+                $vmName = "non-existent-vm"
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+
+                # Act
+                $result = Get-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Describe "Get-HvoVms" {
+        It "Should return the list of all VMs" {
+            # Arrange
+                $vm1 = [PSCustomObject]@{
+                    Name = "vm1"
+                    State = "Running"
+                    CPUUsage = 30
+                    MemoryAssigned = 512MB
+                    Uptime = New-TimeSpan -Hours 2
+                }
+                $vm1 | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                $vm2 = [PSCustomObject]@{
+                    Name = "vm2"
+                    State = "Off"
+                    CPUUsage = 0
+                    MemoryAssigned = 0
+                    Uptime = New-TimeSpan
+                }
+                $vm2 | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                $mockVms = @($vm1, $vm2)
+
+            Mock Get-VM -MockWith { return $mockVms }
+
+            # Act
+            $result = Get-HvoVms
+
+            # Assert
+            $result | Should -Not -BeNullOrEmpty
+            $result.Count | Should -Be 2
+            $result[0].Name | Should -Be "vm1"
+            $result[1].Name | Should -Be "vm2"
+            Should -Invoke Get-VM -Exactly -Times 1
+        }
+
+        It "Should return an empty array if there are no VMs" {
+            # Arrange
+            Mock Get-VM -MockWith { return @() }
+
+            # Act
+            $result = Get-HvoVms
+
+            # Assert
+            # ForEach-Object on an empty array returns $null, so we accept both cases
+            if ($null -eq $result) {
+                $result = @()
+            }
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Describe "Set-HvoVm" {
+        Context "When the VM does not exist" {
+            It "Should return Updated = false with an error" {
+                # Arrange
+                $vmName = "non-existent-vm"
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+
+                # Act
+                $result = Set-HvoVm -Name $vmName -MemoryMB 2048
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Updated | Should -Be $false
+                $result.Error | Should -Be "VM not found"
+            }
+        }
+
+        Context "When the VM is not stopped" {
+            It "Should return Updated = false with an error" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+
+                # Act
+                $result = Set-HvoVm -Name $vmName -MemoryMB 2048
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Updated | Should -Be $false
+                $result.Error | Should -Be "VM must be Off to update"
+                $result.State | Should -Be "Running"
+            }
+        }
+
+        Context "When the VM is stopped" {
+            It "Should update memory if different" {
+                # Arrange
+                $vmName = "stopped-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = [Microsoft.HyperV.PowerShell.VMState]::Off
+                    MemoryStartup = 1GB
+                    ProcessorCount = 2
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -MockWith { return $null }
+                Mock Set-VMMemory -MockWith { }
+
+                # Act
+                $result = Set-HvoVm -Name $vmName -MemoryMB 2048
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Updated | Should -Be $true
+                Should -Invoke Set-VMMemory -Exactly -Times 1 -ParameterFilter {
+                    $VMName -eq $vmName -and $StartupBytes -eq (2048 * 1MB)
+                }
+            }
+
+            It "Should update the number of vCPUs if different" {
+                # Arrange
+                $vmName = "stopped-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = [Microsoft.HyperV.PowerShell.VMState]::Off
+                    MemoryStartup = 1GB
+                    ProcessorCount = 2
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -MockWith { return $null }
+                Mock Set-VMProcessor -MockWith { }
+
+                # Act
+                $result = Set-HvoVm -Name $vmName -Vcpu 4
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Updated | Should -Be $true
+                Should -Invoke Set-VMProcessor -Exactly -Times 1 -ParameterFilter {
+                    $VMName -eq $vmName -and $Count -eq 4
+                }
+            }
+
+            It "Should return Unchanged = true if no changes are needed" {
+                # Arrange
+                $vmName = "stopped-vm"
+                # Use exactly 1024MB to avoid precision issues
+                $memoryBytes = 1024 * 1MB
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Off"
+                    MemoryStartup = $memoryBytes
+                    ProcessorCount = 2
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                $mockNic = [PSCustomObject]@{
+                    SwitchName = "existing-switch"
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                # Get-VMNetworkAdapter can return a single object or an array
+                # The code uses $currentNic?.SwitchName which works on a single object
+                # For this test, we simulate a single object (not an array) so the code works
+                Mock Get-VMNetworkAdapter -MockWith { return $mockNic }
+                Mock Get-VMDvdDrive -MockWith { return $null }
+                Mock Set-VMMemory -MockWith { }
+                Mock Set-VMProcessor -MockWith { }
+                Mock Remove-VMNetworkAdapter -MockWith { }
+                Mock Add-VMNetworkAdapter -MockWith { }
+                Mock Remove-VMDvdDrive -MockWith { }
+                Mock Add-VMDvdDrive -MockWith { }
+
+                # Act
+                $result = Set-HvoVm -Name $vmName -MemoryMB 1024 -Vcpu 2 -SwitchName "existing-switch"
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Updated | Should -Be $false
+                $result.Unchanged | Should -Be $true
+                # Verify that no modifications were made
+                Should -Not -Invoke Set-VMMemory
+                Should -Not -Invoke Set-VMProcessor
+                Should -Not -Invoke Remove-VMNetworkAdapter
+                Should -Not -Invoke Add-VMNetworkAdapter
+            }
+
+            It "Should update the switch if different" {
+                # Arrange
+                $vmName = "stopped-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = [Microsoft.HyperV.PowerShell.VMState]::Off
+                    MemoryStartup = 1GB
+                    ProcessorCount = 2
+                }
+
+                $mockNic = [PSCustomObject]@{
+                    SwitchName = "old-switch"
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -MockWith { return $mockNic }
+                Mock Get-VMDvdDrive -MockWith { return $null }
+                Mock Remove-VMNetworkAdapter -MockWith { }
+                Mock Add-VMNetworkAdapter -MockWith { }
+
+                # Act
+                $result = Set-HvoVm -Name $vmName -SwitchName "new-switch"
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Updated | Should -Be $true
+                Should -Invoke Remove-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter {
+                    $VMName -eq $vmName
+                }
+                Should -Invoke Add-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter {
+                    $VMName -eq $vmName -and $SwitchName -eq "new-switch"
+                }
+            }
+
+            It "Should return an error if ISO file does not exist" {
+                # Arrange
+                $vmName = "stopped-vm"
+                $isoPath = "C:\ISOs\nonexistent.iso"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = [Microsoft.HyperV.PowerShell.VMState]::Off
+                    MemoryStartup = 1GB
+                    ProcessorCount = 2
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -MockWith { return $null }
+                Mock Test-Path -ParameterFilter { $Path -eq $isoPath } -MockWith { return $false }
+
+                # Act
+                $result = Set-HvoVm -Name $vmName -IsoPath $isoPath
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Updated | Should -Be $false
+                $result.Error | Should -Be "ISO file not found"
+                $result.Path | Should -Be $isoPath
+            }
+        }
+    }
+
+    Describe "Start-HvoVm" {
+        Context "When the VM does not exist" {
+            It "Should return null" {
+                # Arrange
+                $vmName = "non-existent-vm"
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+
+                # Act
+                $result = Start-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        Context "When the VM is already running" {
+            It "Should return AlreadyRunning = true" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Start-VM -MockWith { }
+
+                # Act
+                $result = Start-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Started | Should -Be $false
+                $result.AlreadyRunning | Should -Be $true
+                Should -Not -Invoke Start-VM
+            }
+        }
+
+        Context "When the VM is stopped" {
+            It "Should start the VM" {
+                # Arrange
+                $vmName = "stopped-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Off"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Start-VM -MockWith { }
+
+                # Act
+                $result = Start-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Started | Should -Be $true
+                $result.AlreadyRunning | Should -Be $false
+                Should -Invoke Start-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+            }
+        }
+
+        Context "When the VM is paused" {
+            It "Should resume the VM" {
+                # Arrange
+                $vmName = "paused-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Paused"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Resume-VM -MockWith { }
+
+                # Act
+                $result = Start-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Started | Should -Be $true
+                $result.Resumed | Should -Be $true
+                Should -Invoke Resume-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+            }
+        }
+
+        Context "When the VM is saved" {
+            It "Should start the VM from saved state" {
+                # Arrange
+                $vmName = "saved-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Saved"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Start-VM -MockWith { }
+
+                # Act
+                $result = Start-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Started | Should -Be $true
+                $result.Resumed | Should -Be $false
+                Should -Invoke Start-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+            }
+        }
+
+        Context "When the VM is in an invalid state" {
+            It "Should throw an exception for invalid state" {
+                # Arrange
+                $vmName = "invalid-state-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Starting"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+
+                # Act & Assert
+                { Start-HvoVm -Name $vmName } | Should -Throw "*invalid state for starting*"
+            }
+        }
+
+        Context "When an exception occurs" {
+            It "Should propagate exceptions that are not 'not found' errors" {
+                # Arrange
+                $vmName = "vm-with-error"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Off"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Start-VM -MockWith { throw "Access denied" }
+
+                # Act & Assert
+                { Start-HvoVm -Name $vmName } | Should -Throw "Access denied"
+            }
+        }
+    }
+
+    Describe "Stop-HvoVm" {
+        Context "When the VM does not exist" {
+            It "Should return null" {
+                # Arrange
+                $vmName = "non-existent-vm"
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+
+                # Act
+                $result = Stop-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        Context "When the VM is already stopped" {
+            It "Should return AlreadyStopped = true" {
+                # Arrange
+                $vmName = "stopped-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Off"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Stop-VM -MockWith { }
+
+                # Act
+                $result = Stop-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Stopped | Should -Be $false
+                $result.AlreadyStopped | Should -Be $true
+                Should -Not -Invoke Stop-VM
+            }
+        }
+
+        Context "When the VM is running" {
+            It "Should stop the VM with force if the Force parameter is used" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Stop-VM -MockWith { }
+
+                # Act
+                $result = Stop-HvoVm -Name $vmName -Force
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Stopped | Should -Be $true
+                Should -Invoke Stop-VM -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $vmName -and $Force -eq $true
+                }
+            }
+
+            It "Should stop the VM gracefully when shutdown service is available and enabled" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                $mockShutdownService = [PSCustomObject]@{
+                    Name = "Shutdown"
+                    Enabled = $true
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
+                Mock Stop-VM -MockWith { }
+
+                # Act
+                $result = Stop-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Stopped | Should -Be $true
+                Should -Invoke Get-VMIntegrationService -Exactly -Times 1 -ParameterFilter {
+                    $VMName -eq $vmName -and $Name -eq "Shutdown"
+                }
+                Should -Invoke Stop-VM -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $vmName -and -not $PSBoundParameters.ContainsKey('Force')
+                }
+            }
+
+            It "Should throw an exception when shutdown service is not available" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $null }
+                Mock Stop-VM -MockWith { }
+
+                # Act & Assert
+                { Stop-HvoVm -Name $vmName } | Should -Throw "*SHUTDOWN_SERVICE_NOT_AVAILABLE*"
+                Should -Not -Invoke Stop-VM
+            }
+
+            It "Should throw an exception when shutdown service is not enabled" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                $mockShutdownService = [PSCustomObject]@{
+                    Name = "Shutdown"
+                    Enabled = $false
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
+                Mock Stop-VM -MockWith { }
+
+                # Act & Assert
+                { Stop-HvoVm -Name $vmName } | Should -Throw "*SHUTDOWN_SERVICE_NOT_ENABLED*"
+                Should -Not -Invoke Stop-VM
+            }
+        }
+    }
+
+    Describe "Restart-HvoVm" {
+        Context "When the VM does not exist" {
+            It "Should return null" {
+                # Arrange
+                $vmName = "non-existent-vm"
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+
+                # Act
+                $result = Restart-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        Context "When the VM is stopped" {
+            It "Should start the VM (idempotence)" {
+                # Arrange
+                $vmName = "stopped-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Off"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Start-VM -MockWith { }
+
+                # Act
+                $result = Restart-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Restarted | Should -Be $true
+                Should -Invoke Start-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+            }
+        }
+
+        Context "When the VM is running" {
+            It "Should restart the VM with force if the Force parameter is used" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Restart-VM -MockWith { }
+
+                # Act
+                $result = Restart-HvoVm -Name $vmName -Force
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Restarted | Should -Be $true
+                Should -Invoke Restart-VM -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $vmName -and $Force -eq $true
+                }
+            }
+
+            It "Should restart the VM gracefully when shutdown service is available and enabled" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                $mockShutdownService = [PSCustomObject]@{
+                    Name = "Shutdown"
+                    Enabled = $true
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
+                Mock Restart-VM -MockWith { }
+
+                # Act
+                $result = Restart-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Restarted | Should -Be $true
+                Should -Invoke Get-VMIntegrationService -Exactly -Times 1 -ParameterFilter {
+                    $VMName -eq $vmName -and $Name -eq "Shutdown"
+                }
+                Should -Invoke Restart-VM -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $vmName -and -not $PSBoundParameters.ContainsKey('Force')
+                }
+            }
+
+            It "Should throw an exception when shutdown service is not available" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $null }
+                Mock Restart-VM -MockWith { }
+
+                # Act & Assert
+                { Restart-HvoVm -Name $vmName } | Should -Throw "*SHUTDOWN_SERVICE_NOT_AVAILABLE*"
+                Should -Not -Invoke Restart-VM
+            }
+
+            It "Should throw an exception when shutdown service is not enabled" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                $mockShutdownService = [PSCustomObject]@{
+                    Name = "Shutdown"
+                    Enabled = $false
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
+                Mock Restart-VM -MockWith { }
+
+                # Act & Assert
+                { Restart-HvoVm -Name $vmName } | Should -Throw "*SHUTDOWN_SERVICE_NOT_ENABLED*"
+                Should -Not -Invoke Restart-VM
+            }
+        }
+    }
+
+    Describe "Suspend-HvoVm" {
+        Context "When the VM does not exist" {
+            It "Should return null" {
+                # Arrange
+                $vmName = "non-existent-vm"
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+
+                # Act
+                $result = Suspend-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        Context "When the VM is already paused" {
+            It "Should return AlreadySuspended = true" {
+                # Arrange
+                $vmName = "paused-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Paused"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Suspend-VM -MockWith { }
+
+                # Act
+                $result = Suspend-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Suspended | Should -Be $false
+                $result.AlreadySuspended | Should -Be $true
+                Should -Not -Invoke Suspend-VM
+            }
+        }
+
+        Context "When the VM is running" {
+            It "Should suspend the VM" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Suspend-VM -MockWith { }
+
+                # Act
+                $result = Suspend-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Suspended | Should -Be $true
+                $result.AlreadySuspended | Should -Be $false
+                Should -Invoke Suspend-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+            }
+        }
+
+        Context "When the VM is in an invalid state" {
+            It "Should throw an exception for invalid state" {
+                # Arrange
+                $vmName = "invalid-state-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Off"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+
+                # Act & Assert
+                { Suspend-HvoVm -Name $vmName } | Should -Throw "*invalid state for suspending*"
+            }
+        }
+
+        Context "When an exception occurs" {
+            It "Should propagate exceptions that are not 'not found' errors" {
+                # Arrange
+                $vmName = "vm-with-error"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Suspend-VM -MockWith { throw "Access denied" }
+
+                # Act & Assert
+                { Suspend-HvoVm -Name $vmName } | Should -Throw "Access denied"
+            }
+        }
+    }
+
+    Describe "Resume-HvoVm" {
+        Context "When the VM does not exist" {
+            It "Should return null" {
+                # Arrange
+                $vmName = "non-existent-vm"
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+
+                # Act
+                $result = Resume-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        Context "When the VM is already running" {
+            It "Should return AlreadyRunning = true" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Resume-VM -MockWith { }
+
+                # Act
+                $result = Resume-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Resumed | Should -Be $false
+                $result.AlreadyRunning | Should -Be $true
+                Should -Not -Invoke Resume-VM
+            }
+        }
+
+        Context "When the VM is paused" {
+            It "Should resume the VM" {
+                # Arrange
+                $vmName = "paused-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Paused"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Resume-VM -MockWith { }
+
+                # Act
+                $result = Resume-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Resumed | Should -Be $true
+                $result.AlreadyRunning | Should -Be $false
+                Should -Invoke Resume-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+            }
+        }
+
+        Context "When the VM is stopped" {
+            It "Should throw an exception" {
+                # Arrange
+                $vmName = "stopped-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Off"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+
+                # Act & Assert
+                { Resume-HvoVm -Name $vmName } | Should -Throw
+            }
+        }
+    }
+
+    Describe "Remove-HvoVm" {
+        Context "When the VM does not exist" {
+            It "Should return false" {
+                # Arrange
+                $vmName = "non-existent-vm"
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+                Mock Remove-VM -MockWith { }
+
+                # Act
+                $result = Remove-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Be $false
+                Should -Not -Invoke Remove-VM
+            }
+        }
+
+        Context "When the VM exists" {
+            It "Should stop the VM if it is running before deletion" {
+                # Arrange
+                $vmName = "running-vm"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Running"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Stop-VM -MockWith { }
+                Mock Get-VMSnapshot -MockWith { return $null }
+                Mock Get-VMDvdDrive -MockWith { return @() }
+                Mock Get-VMHardDiskDrive -MockWith { return @() }
+                Mock Remove-VM -MockWith { }
+
+                # Act
+                $result = Remove-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Be $true
+                Should -Invoke Stop-VM -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $vmName -and $Force -eq $true
+                }
+                Should -Invoke Remove-VM -Exactly -Times 1 -ParameterFilter {
+                    $Name -eq $vmName -and $Force -eq $true
+                }
+            }
+
+            It "Should remove snapshots before deletion" {
+                # Arrange
+                $vmName = "vm-with-snapshots"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Off"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+                $mockSnapshots = @(
+                    [PSCustomObject]@{ Name = "snapshot1" },
+                    [PSCustomObject]@{ Name = "snapshot2" }
+                )
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMSnapshot -MockWith { return $mockSnapshots }
+                Mock Remove-VMSnapshot -MockWith { }
+                Mock Get-VMDvdDrive -MockWith { return @() }
+                Mock Get-VMHardDiskDrive -MockWith { return @() }
+                Mock Remove-VM -MockWith { }
+
+                # Act
+                $result = Remove-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Be $true
+                Should -Invoke Remove-VMSnapshot -Exactly -Times 1 -ParameterFilter {
+                    $VMName -eq $vmName
+                }
+            }
+
+            It "Should remove disks if RemoveDisks is true" {
+                # Arrange
+                $vmName = "vm-with-disks"
+                $diskPath = "C:\VMs\vm-with-disks.vhdx"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Off"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+                $mockDisk = [PSCustomObject]@{
+                    Path = $diskPath
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMSnapshot -MockWith { return $null }
+                Mock Get-VMDvdDrive -MockWith { return @() }
+                Mock Get-VMHardDiskDrive -MockWith { return @($mockDisk) }
+                Mock Test-Path -ParameterFilter { $Path -eq $diskPath } -MockWith { return $true }
+                Mock Remove-Item -MockWith { }
+                Mock Remove-VM -MockWith { }
+
+                # Act
+                $result = Remove-HvoVm -Name $vmName -RemoveDisks $true
+
+                # Assert
+                $result | Should -Be $true
+                Should -Invoke Remove-Item -Exactly -Times 1 -ParameterFilter {
+                    $Path -eq $diskPath -and $Force -eq $true
+                }
+            }
+
+            It "Should remove DVD drives before deletion" {
+                # Arrange
+                $vmName = "vm-with-dvd"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Off"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+                $mockDvdDrive = [PSCustomObject]@{
+                    ControllerNumber = 0
+                    ControllerLocation = 0
+                }
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMSnapshot -MockWith { return $null }
+                Mock Get-VMDvdDrive -MockWith { return @($mockDvdDrive) }
+                Mock Remove-VMDvdDrive -MockWith { }
+                Mock Get-VMHardDiskDrive -MockWith { return @() }
+                Mock Remove-VM -MockWith { }
+
+                # Act
+                $result = Remove-HvoVm -Name $vmName
+
+                # Assert
+                $result | Should -Be $true
+                Should -Invoke Remove-VMDvdDrive -Exactly -Times 1 -ParameterFilter {
+                    $VMName -eq $vmName -and
+                    $ControllerNumber -eq 0 -and
+                    $ControllerLocation -eq 0
+                }
+            }
+
+            It "Should handle exceptions that are not 'not found' errors" {
+                # Arrange
+                $vmName = "vm-with-error"
+                $mockVm = [PSCustomObject]@{
+                    Name = $vmName
+                    State = "Off"
+                }
+                $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+
+                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VMSnapshot -MockWith { return $null }
+                Mock Get-VMDvdDrive -MockWith { return @() }
+                Mock Get-VMHardDiskDrive -MockWith { return @() }
+                Mock Remove-VM -MockWith { throw "Access denied" }
+
+                # Act & Assert
+                { Remove-HvoVm -Name $vmName } | Should -Throw "Access denied"
+            }
+        }
+    }
+}

--- a/tests/unit/utils.Tests.ps1
+++ b/tests/unit/utils.Tests.ps1
@@ -1,0 +1,121 @@
+# Unit tests for the utils module
+# Uses InModuleScope to test within the module context
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot "../../src/utils.psm1"
+    Import-Module $modulePath -Force
+}
+
+InModuleScope utils {
+    Describe "Get-HvoJsonBody" {
+        Context "When WebEvent.Data exists" {
+            It "Should return WebEvent.Data directly" {
+                # Arrange
+                $mockData = @{
+                    Name = "test"
+                    Value = 123
+                }
+
+                # Simulate WebEvent via a script variable in the module scope
+                $script:WebEvent = [PSCustomObject]@{
+                    Data = $mockData
+                }
+
+                # Act
+                $result = Get-HvoJsonBody
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -Be $mockData
+            }
+        }
+
+        Context "When WebEvent.Data does not exist but Request.Body exists" {
+            It "Should parse JSON from Request.Body" {
+                # Arrange
+                $jsonString = '{"Name":"test","Value":123}'
+                $jsonBytes = [System.Text.Encoding]::UTF8.GetBytes($jsonString)
+
+                $mockRequest = [PSCustomObject]@{
+                    Body = $jsonBytes
+                }
+
+                $script:WebEvent = [PSCustomObject]@{
+                    Data = $null
+                    Request = $mockRequest
+                }
+
+                # Act
+                $result = Get-HvoJsonBody
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.Name | Should -Be "test"
+                $result.Value | Should -Be 123
+            }
+        }
+
+        Context "When neither WebEvent.Data nor Request.Body exist" {
+            It "Should return null" {
+                # Arrange
+                $script:WebEvent = [PSCustomObject]@{
+                    Data = $null
+                    Request = [PSCustomObject]@{
+                        Body = $null
+                    }
+                }
+
+                # Act
+                $result = Get-HvoJsonBody
+
+                # Assert
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        Context "When Request.Body contains invalid JSON" {
+            It "Should return null without throwing an exception" {
+                # Arrange
+                $invalidJson = "not valid json"
+                $jsonBytes = [System.Text.Encoding]::UTF8.GetBytes($invalidJson)
+
+                $mockRequest = [PSCustomObject]@{
+                    Body = $jsonBytes
+                }
+
+                $script:WebEvent = [PSCustomObject]@{
+                    Data = $null
+                    Request = $mockRequest
+                }
+
+                # Act
+                $result = Get-HvoJsonBody
+
+                # Assert
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        Context "When Request.Body is empty" {
+            It "Should return null" {
+                # Arrange
+                $emptyBytes = [System.Text.Encoding]::UTF8.GetBytes("")
+
+                $mockRequest = [PSCustomObject]@{
+                    Body = $emptyBytes
+                }
+
+                $script:WebEvent = [PSCustomObject]@{
+                    Data = $null
+                    Request = $mockRequest
+                }
+
+                # Act
+                $result = Get-HvoJsonBody
+
+                # Assert
+                $result | Should -BeNullOrEmpty
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add comprehensive test suite for HvoVm and HvoSwitch modules, fix a bug in VM network adapter handling, and update OpenAPI documentation.

---

## Type of change

- [x] Feature (new functionality)
- [x] Fix (bug fix)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Chore / maintenance

---

## Context

The project lacked unit tests to validate the behavior of HvoVm and HvoSwitch modules. Additionally, a bug was identified in network adapter handling when Get-VMNetworkAdapter returns an array instead of a single object, causing errors when updating a VM's switch.

---

## Changes

- Add unit tests for HvoVm module covering all functions: Set-HvoVm, Start-HvoVm, Stop-HvoVm, Restart-HvoVm, Suspend-HvoVm, Resume-HvoVm, Remove-HvoVm
- Add unit tests for HvoSwitch module
- Add utility tests
- Add test infrastructure (run-tests.ps1, analyze-coverage.ps1 scripts)
- Add test documentation (README.md)
- Fix array handling for Get-VMNetworkAdapter return value in Set-HvoVm
- Remove Write-Host error messages in favor of exception propagation
- Translate error messages to English for consistency
- Update OpenAPI documentation (JSON and YAML)

---

## Tests

- [x] Manual tests performed
- [x] Existing functionality verified
- [x] Documentation verified

All unit tests pass locally. Tests cover normal use cases, error cases, and parameter validation. OpenAPI documentation has been verified and updated.

---

## Breaking changes

- [ ] This PR introduces breaking changes

---

## Checklist

- [x] Code follows project standards
- [x] Code comments added where necessary
- [x] Documentation updated (README and/or docs)
- [x] No secrets or sensitive information committed
- [x] No new external dependencies introduced

