### PR TITLE
feat(api): identify resources by Id (GUID) and add API scenario test script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [Unreleased]
+
+### Breaking change — Resource identification by Id (GUID)
+
+- **Resources identified by Id:** All list and detail responses now include an **id** field (GUID). Targeting resources (detail, update, delete, actions) is done only via **:id** in the path.
+- **Name-based routes removed:** Routes using **:name** to target a VM or switch have been removed (e.g. `GET /vms/:name`, `PUT /vms/:name`, `DELETE /vms/:name`, `POST /vms/:name/start`, etc.).
+- **Discovery by name:** Use **GET /vms/by-name/:name** and **GET /switches/by-name/:name** to look up resources by name. The response is always an array (200), possibly empty.
+- **Creation (POST /vms, POST /switches):** Each call creates a **new** resource and returns **201 Created** with **id**. There is no longer a 200 “already exists” response; names may be duplicated; the stable identifier is **id**.
+- **Network adapters:** Adapter lists include **id** per adapter. Removing an adapter is done via **DELETE /vms/:id/network-adapters/:adapterId**.
+
+See [docs/api-reference.md](docs/api-reference.md) for the full endpoint reference.

--- a/docs/dod/README.md
+++ b/docs/dod/README.md
@@ -104,7 +104,11 @@ Static OpenAPI specification files must be generated and kept up to date in the 
 
 ### Generation Script
 
-The OpenAPI specification can be automatically generated using the provided script located at `src/scripts/generate-openapi.ps1`.
+The OpenAPI specification can be automatically generated using the provided script :
+
+```powershell
+src/scripts/generate-openapi.ps1
+```
 
 **What the script does:**
 

--- a/docs/dod/README.md
+++ b/docs/dod/README.md
@@ -98,6 +98,48 @@ Analyze code coverage by component using the coverage analysis script:
 
 This script provides a breakdown of coverage by items, helping identify areas that need additional test coverage.
 
+## API Scenario Tests
+
+En plus des tests unitaires, un scénario de test complet exerce l’API contre un serveur déjà démarré (localhost). Il valide l’enchaînement des endpoints (health, documentation, switches, VMs) et génère un rapport.
+
+### Prérequis
+
+- Le serveur API doit être démarré (voir [End-User Testing](#end-user-testing) pour le lancer).
+- Hyper-V disponible sur la machine où tourne le serveur.
+- PowerShell 7 (requis pour les appels HTTP du script).
+
+### Exécution
+
+```powershell
+.\tests\run-api-tests.ps1
+```
+
+Options possibles :
+
+```powershell
+.\tests\run-api-tests.ps1 -BaseUrl 'http://localhost:8080' -VmDiskPath 'C:\ProgramData\hvo-api-test'
+```
+
+Le script demande une confirmation que le serveur est démarré, vérifie `GET /health`, puis enchaîne :
+
+1. **Phase 1** : health, OpenAPI (documentation).
+2. **Phase 2** : CRUD des switches (liste, création, lecture, mise à jour, suppression).
+3. **Phase 3** : scénario VM (liste, création, lecture, démarrage, arrêt, adaptateurs réseau, mise à jour, suppression).
+
+Les ressources créées utilisent le préfixe `hvo-test-{type}-<YYYYMMDDHHmm>` et sont supprimées en fin de run lorsque les tests réussissent.
+
+### Rapport et échecs
+
+Un rapport est généré dans `tests/reports/api-test-report-<YYYYMMDDHHmm>.txt`. En cas d’échec, le rapport contient :
+
+- La liste des tests en échec (endpoint, code HTTP, réponse).
+- Une section **Remise en condition initiale Hyper-V** avec les commandes PowerShell pour supprimer les ressources de test restantes (VMs et switches dont le nom commence par `hvo-test-`).
+
+### Quand les exécuter
+
+- Après une modification des routes ou du comportement de l’API (switches, VMs, health, documentation).
+- Avant une release ou une validation de feature, en complément des tests unitaires et des tests manuels via Swagger.
+
 ## OpenAPI Documentation
 
 Static OpenAPI specification files must be generated and kept up to date in the `docs/` directory.
@@ -160,3 +202,4 @@ The server starts by default on `http://127.0.0.1:8080`.
 - Returned data conforms to the OpenAPI schema
 - Changes are properly reflected in Hyper-V
 - Error cases are handled correctly
+- **API scenario tests** : `.\tests\run-api-tests.ps1` a été exécuté avec succès (recommandé après toute modification des routes ou du comportement de l’API)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -200,6 +200,9 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "Id": {
+                        "type": "string"
+                      },
                       "Name": {
                         "type": "string"
                       },
@@ -217,6 +220,7 @@
                       }
                     },
                     "required": [
+                      "Id",
                       "Name",
                       "State",
                       "CPUUsage",
@@ -248,7 +252,7 @@
           "VMs"
         ],
         "summary": "Create a new virtual machine",
-        "description": "Creates a new virtual machine with the specified configuration. Returns 200 if VM already exists (idempotent)",
+        "description": "Creates a new virtual machine. Each call creates a new resource and returns 201 with id (GUID). Names may be duplicated.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -261,22 +265,7 @@
         },
         "responses": {
           "200": {
-            "description": "VM already exists",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "exists": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "exists"
-                  ]
-                }
-              }
-            }
+            "description": "OK"
           },
           "default": {
             "description": "Internal server error"
@@ -290,10 +279,14 @@
                   "properties": {
                     "created": {
                       "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
                     }
                   },
                   "required": [
-                    "created"
+                    "created",
+                    "id"
                   ]
                 }
               }
@@ -322,21 +315,21 @@
         }
       }
     },
-    "/vms/{name}": {
+    "/vms/{id}": {
       "get": {
         "tags": [
           "VMs"
         ],
-        "summary": "Get virtual machine details",
-        "description": "Returns detailed information about a specific virtual machine",
+        "summary": "Get virtual machine details by Id",
+        "description": "Returns detailed information about a specific virtual machine by its GUID",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           }
         ],
         "responses": {
@@ -380,15 +373,15 @@
           "VMs"
         ],
         "summary": "Update a virtual machine",
-        "description": "Updates configuration of an existing virtual machine. VM must be stopped. Returns 200 with unchanged=true if no changes were needed",
+        "description": "Updates configuration of an existing virtual machine by Id. VM must be stopped.",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           }
         ],
         "requestBody": {
@@ -473,15 +466,15 @@
           "VMs"
         ],
         "summary": "Delete a virtual machine",
-        "description": "Deletes a virtual machine and its associated virtual hard disks",
+        "description": "Deletes a virtual machine by Id and its associated virtual hard disks",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           }
         ],
         "responses": {
@@ -529,21 +522,96 @@
         }
       }
     },
-    "/vms/{name}/start": {
+    "/vms/by-name/{name}": {
+      "get": {
+        "tags": [
+          "VMs"
+        ],
+        "summary": "Get VMs by name",
+        "description": "Returns an array of virtual machines matching the given name (may be 0, 1 or more)",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of VMs with matching name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "Id": {
+                        "type": "string"
+                      },
+                      "Name": {
+                        "type": "string"
+                      },
+                      "State": {
+                        "type": "string"
+                      },
+                      "CPUUsage": {
+                        "type": "integer"
+                      },
+                      "MemoryAssigned": {
+                        "type": "integer"
+                      },
+                      "Uptime": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "Id",
+                      "Name",
+                      "State",
+                      "CPUUsage",
+                      "MemoryAssigned",
+                      "Uptime"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Internal server error"
+          },
+          "500": {
+            "description": "Failed to get VMs by name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vms/{id}/start": {
       "post": {
         "tags": [
           "VMs"
         ],
         "summary": "Start a virtual machine",
-        "description": "Starts a virtual machine. If the VM is paused, it will be resumed",
+        "description": "Starts a virtual machine by Id. If the VM is paused, it will be resumed",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           }
         ],
         "responses": {
@@ -591,28 +659,28 @@
         }
       }
     },
-    "/vms/{name}/stop": {
+    "/vms/{id}/stop": {
       "post": {
         "tags": [
           "VMs"
         ],
         "summary": "Stop a virtual machine",
-        "description": "Stops a virtual machine gracefully. Use force=true query parameter or body to force shutdown",
+        "description": "Stops a virtual machine by Id. Use force=true query or body to force shutdown",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           },
           {
-            "name": "force",
             "schema": {
               "type": "boolean"
             },
-            "in": "query"
+            "in": "query",
+            "name": "force"
           }
         ],
         "requestBody": {
@@ -694,28 +762,28 @@
         }
       }
     },
-    "/vms/{name}/restart": {
+    "/vms/{id}/restart": {
       "post": {
         "tags": [
           "VMs"
         ],
         "summary": "Restart a virtual machine",
-        "description": "Restarts a virtual machine. Use force=true query parameter or body to force shutdown before restart",
+        "description": "Restarts a virtual machine by Id. Use force=true query or body to force shutdown before restart",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           },
           {
-            "name": "force",
             "schema": {
               "type": "boolean"
             },
-            "in": "query"
+            "in": "query",
+            "name": "force"
           }
         ],
         "requestBody": {
@@ -787,21 +855,21 @@
         }
       }
     },
-    "/vms/{name}/suspend": {
+    "/vms/{id}/suspend": {
       "post": {
         "tags": [
           "VMs"
         ],
         "summary": "Suspend a virtual machine",
-        "description": "Suspends (pauses) a running virtual machine",
+        "description": "Suspends (pauses) a running virtual machine by Id",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           }
         ],
         "responses": {
@@ -859,21 +927,21 @@
         }
       }
     },
-    "/vms/{name}/resume": {
+    "/vms/{id}/resume": {
       "post": {
         "tags": [
           "VMs"
         ],
         "summary": "Resume a virtual machine",
-        "description": "Resumes a suspended virtual machine",
+        "description": "Resumes a suspended virtual machine by Id",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           }
         ],
         "responses": {
@@ -931,21 +999,21 @@
         }
       }
     },
-    "/vms/{name}/network-adapters": {
+    "/vms/{id}/network-adapters": {
       "get": {
         "tags": [
           "VMs"
         ],
         "summary": "List network adapters of a virtual machine",
-        "description": "Returns a list of all network adapters for a specific virtual machine",
+        "description": "Returns a list of all network adapters for a VM by Id (each adapter includes Id)",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           }
         ],
         "responses": {
@@ -958,6 +1026,9 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "Id": {
+                        "type": "string"
+                      },
                       "Name": {
                         "type": "string"
                       },
@@ -977,8 +1048,7 @@
                     "required": [
                       "Name",
                       "Type",
-                      "MacAddress",
-                      "Status"
+                      "MacAddress"
                     ]
                   }
                 }
@@ -1009,6 +1079,160 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": [
+          "VMs"
+        ],
+        "summary": "Add a network adapter to a VM",
+        "description": "Adds a network adapter to a virtual machine by Id. Returns 201 with adapter id.",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "switchName": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "switchName"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Internal server error"
+          },
+          "201": {
+            "description": "Adapter created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "created": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "VM not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to add adapter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vms/{id}/network-adapters/{adapterId}": {
+      "delete": {
+        "tags": [
+          "VMs"
+        ],
+        "summary": "Remove a network adapter from a VM",
+        "description": "Removes a network adapter by adapter Id from a VM by Id",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "adapterId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Adapter removed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "deleted": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Internal server error"
+          },
+          "404": {
+            "description": "VM or adapter not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to remove adapter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/switches": {
@@ -1028,6 +1252,9 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "Id": {
+                        "type": "string"
+                      },
                       "Name": {
                         "type": "string"
                       },
@@ -1044,6 +1271,7 @@
                       }
                     },
                     "required": [
+                      "Id",
                       "Name",
                       "SwitchType"
                     ]
@@ -1072,7 +1300,7 @@
           "Switches"
         ],
         "summary": "Create a new virtual switch",
-        "description": "Creates a new virtual switch. For External switches, netAdapterName is required. Returns 200 if switch already exists (idempotent)",
+        "description": "Creates a new virtual switch. Each call returns 201 with id. For External switches, netAdapterName is required.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1085,22 +1313,7 @@
         },
         "responses": {
           "200": {
-            "description": "Switch already exists",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "exists": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "exists"
-                  ]
-                }
-              }
-            }
+            "description": "OK"
           },
           "default": {
             "description": "Internal server error"
@@ -1114,10 +1327,14 @@
                   "properties": {
                     "created": {
                       "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
                     }
                   },
                   "required": [
-                    "created"
+                    "created",
+                    "id"
                   ]
                 }
               }
@@ -1146,21 +1363,21 @@
         }
       }
     },
-    "/switches/{name}": {
+    "/switches/{id}": {
       "get": {
         "tags": [
           "Switches"
         ],
-        "summary": "Get virtual switch details",
-        "description": "Returns detailed information about a specific virtual switch",
+        "summary": "Get virtual switch details by Id",
+        "description": "Returns detailed information about a specific virtual switch by its GUID",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           }
         ],
         "responses": {
@@ -1204,15 +1421,15 @@
           "Switches"
         ],
         "summary": "Update a virtual switch",
-        "description": "Updates the notes field of an existing virtual switch",
+        "description": "Updates the notes field of an existing virtual switch by Id",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           }
         ],
         "requestBody": {
@@ -1284,15 +1501,15 @@
           "Switches"
         ],
         "summary": "Delete a virtual switch",
-        "description": "Deletes a virtual switch",
+        "description": "Deletes a virtual switch by Id",
         "parameters": [
           {
-            "name": "name",
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "in": "path"
+            "in": "path",
+            "name": "id"
           }
         ],
         "responses": {
@@ -1329,6 +1546,72 @@
           },
           "500": {
             "description": "Failed to delete switch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/switches/by-name/{name}": {
+      "get": {
+        "tags": [
+          "Switches"
+        ],
+        "summary": "Get switches by name",
+        "description": "Returns an array of virtual switches matching the given name",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of switches with matching name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "Id": {
+                        "type": "string"
+                      },
+                      "Name": {
+                        "type": "string"
+                      },
+                      "SwitchType": {
+                        "type": "string"
+                      },
+                      "Notes": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "Id",
+                      "Name",
+                      "SwitchType"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Internal server error"
+          },
+          "500": {
+            "description": "Failed to get switches by name",
             "content": {
               "application/json": {
                 "schema": {
@@ -1384,6 +1667,9 @@
       "VmSchema": {
         "type": "object",
         "properties": {
+          "Id": {
+            "type": "string"
+          },
           "Name": {
             "type": "string"
           },
@@ -1401,6 +1687,7 @@
           }
         },
         "required": [
+          "Id",
           "Name",
           "State",
           "CPUUsage",
@@ -1500,6 +1787,9 @@
       "SwitchSchema": {
         "type": "object",
         "properties": {
+          "Id": {
+            "type": "string"
+          },
           "Name": {
             "type": "string"
           },
@@ -1516,6 +1806,7 @@
           }
         },
         "required": [
+          "Id",
           "Name",
           "SwitchType"
         ]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -131,6 +131,8 @@ paths:
                 items:
                   type: object
                   properties:
+                    Id:
+                      type: string
                     Name:
                       type: string
                     State:
@@ -142,6 +144,7 @@ paths:
                     Uptime:
                       type: string
                   required:
+                    - Id
                     - Name
                     - State
                     - CPUUsage
@@ -160,8 +163,8 @@ paths:
         - VMs
       summary: Create a new virtual machine
       description: |
-          Creates a new virtual machine with the specified configuration. Returns 200 if
-          VM already exists (idempotent)
+          Creates a new virtual machine. Each call creates a new resource and returns 201
+          with id (GUID). Names may be duplicated.
       requestBody:
         content:
           application/json:
@@ -170,16 +173,7 @@ paths:
         required: true
       responses:
         200:
-          description: VM already exists
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  exists:
-                    type: string
-                required:
-                  - exists
+          description: OK
         default:
           description: Internal server error
         201:
@@ -191,8 +185,11 @@ paths:
                 properties:
                   created:
                     type: string
+                  id:
+                    type: string
                 required:
                   - created
+                  - id
         400:
           description: Invalid JSON
           content:
@@ -205,18 +202,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
-  /vms/{name}:
+  /vms/{id}:
     get:
       tags:
         - VMs
-      summary: Get virtual machine details
-      description: Returns detailed information about a specific virtual machine
+      summary: Get virtual machine details by Id
+      description: Returns detailed information about a specific virtual machine by its GUID
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
+          name: id
       responses:
         200:
           description: Virtual machine details
@@ -242,15 +239,13 @@ paths:
       tags:
         - VMs
       summary: Update a virtual machine
-      description: |
-          Updates configuration of an existing virtual machine. VM must be stopped.
-          Returns 200 with unchanged=true if no changes were needed
+      description: Updates configuration of an existing virtual machine by Id. VM must be stopped.
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
+          name: id
       requestBody:
         content:
           application/json:
@@ -301,13 +296,13 @@ paths:
       tags:
         - VMs
       summary: Delete a virtual machine
-      description: Deletes a virtual machine and its associated virtual hard disks
+      description: Deletes a virtual machine by Id and its associated virtual hard disks
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
+          name: id
       responses:
         200:
           description: VM deleted successfully
@@ -334,18 +329,69 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
-  /vms/{name}/start:
+  /vms/by-name/{name}:
+    get:
+      tags:
+        - VMs
+      summary: Get VMs by name
+      description: |
+          Returns an array of virtual machines matching the given name (may be 0, 1 or
+          more)
+      parameters:
+        - required: true
+          schema:
+            type: string
+          in: path
+          name: name
+      responses:
+        200:
+          description: Array of VMs with matching name
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    Id:
+                      type: string
+                    Name:
+                      type: string
+                    State:
+                      type: string
+                    CPUUsage:
+                      type: integer
+                    MemoryAssigned:
+                      type: integer
+                    Uptime:
+                      type: string
+                  required:
+                    - Id
+                    - Name
+                    - State
+                    - CPUUsage
+                    - MemoryAssigned
+                    - Uptime
+        default:
+          description: Internal server error
+        500:
+          description: Failed to get VMs by name
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+  /vms/{id}/start:
     post:
       tags:
         - VMs
       summary: Start a virtual machine
-      description: Starts a virtual machine. If the VM is paused, it will be resumed
+      description: Starts a virtual machine by Id. If the VM is paused, it will be resumed
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
+          name: id
       responses:
         200:
           description: VM started successfully
@@ -372,24 +418,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
-  /vms/{name}/stop:
+  /vms/{id}/stop:
     post:
       tags:
         - VMs
       summary: Stop a virtual machine
-      description: |
-          Stops a virtual machine gracefully. Use force=true query parameter or body to
-          force shutdown
+      description: Stops a virtual machine by Id. Use force=true query or body to force shutdown
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
-        - name: force
-          schema:
+          name: id
+        - schema:
             type: boolean
           in: query
+          name: force
       requestBody:
         content:
           application/json:
@@ -436,24 +480,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
-  /vms/{name}/restart:
+  /vms/{id}/restart:
     post:
       tags:
         - VMs
       summary: Restart a virtual machine
       description: |
-          Restarts a virtual machine. Use force=true query parameter or body to force
-          shutdown before restart
+          Restarts a virtual machine by Id. Use force=true query or body to force shutdown
+          before restart
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
-        - name: force
-          schema:
+          name: id
+        - schema:
             type: boolean
           in: query
+          name: force
       requestBody:
         content:
           application/json:
@@ -494,18 +538,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
-  /vms/{name}/suspend:
+  /vms/{id}/suspend:
     post:
       tags:
         - VMs
       summary: Suspend a virtual machine
-      description: Suspends (pauses) a running virtual machine
+      description: Suspends (pauses) a running virtual machine by Id
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
+          name: id
       responses:
         200:
           description: VM suspended successfully
@@ -538,18 +582,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
-  /vms/{name}/resume:
+  /vms/{id}/resume:
     post:
       tags:
         - VMs
       summary: Resume a virtual machine
-      description: Resumes a suspended virtual machine
+      description: Resumes a suspended virtual machine by Id
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
+          name: id
       responses:
         200:
           description: VM resumed successfully
@@ -582,18 +626,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
-  /vms/{name}/network-adapters:
+  /vms/{id}/network-adapters:
     get:
       tags:
         - VMs
       summary: List network adapters of a virtual machine
-      description: Returns a list of all network adapters for a specific virtual machine
+      description: Returns a list of all network adapters for a VM by Id (each adapter includes Id)
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
+          name: id
       responses:
         200:
           description: List of network adapters
@@ -604,6 +648,8 @@ paths:
                 items:
                   type: object
                   properties:
+                    Id:
+                      type: string
                     Name:
                       type: string
                     SwitchName:
@@ -618,7 +664,6 @@ paths:
                     - Name
                     - Type
                     - MacAddress
-                    - Status
         default:
           description: Internal server error
         404:
@@ -629,6 +674,101 @@ paths:
                 $ref: '#/components/schemas/ErrorSchema'
         500:
           description: Failed to list network adapters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+    post:
+      tags:
+        - VMs
+      summary: Add a network adapter to a VM
+      description: Adds a network adapter to a virtual machine by Id. Returns 201 with adapter id.
+      parameters:
+        - required: true
+          schema:
+            type: string
+          in: path
+          name: id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                switchName:
+                  type: string
+              required:
+                - switchName
+        required: true
+      responses:
+        200:
+          description: OK
+        default:
+          description: Internal server error
+        201:
+          description: Adapter created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: string
+                  id:
+                    type: string
+                required:
+                  - id
+        404:
+          description: VM not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+        500:
+          description: Failed to add adapter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+  /vms/{id}/network-adapters/{adapterId}:
+    delete:
+      tags:
+        - VMs
+      summary: Remove a network adapter from a VM
+      description: Removes a network adapter by adapter Id from a VM by Id
+      parameters:
+        - required: true
+          schema:
+            type: string
+          in: path
+          name: id
+        - required: true
+          schema:
+            type: string
+          in: path
+          name: adapterId
+      responses:
+        200:
+          description: Adapter removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: string
+                  id:
+                    type: string
+        default:
+          description: Internal server error
+        404:
+          description: VM or adapter not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+        500:
+          description: Failed to remove adapter
           content:
             application/json:
               schema:
@@ -649,6 +789,8 @@ paths:
                 items:
                   type: object
                   properties:
+                    Id:
+                      type: string
                     Name:
                       type: string
                     SwitchType:
@@ -660,6 +802,7 @@ paths:
                     Notes:
                       type: string
                   required:
+                    - Id
                     - Name
                     - SwitchType
         default:
@@ -675,8 +818,8 @@ paths:
         - Switches
       summary: Create a new virtual switch
       description: |
-          Creates a new virtual switch. For External switches, netAdapterName is required.
-          Returns 200 if switch already exists (idempotent)
+          Creates a new virtual switch. Each call returns 201 with id. For External
+          switches, netAdapterName is required.
       requestBody:
         content:
           application/json:
@@ -685,16 +828,7 @@ paths:
         required: true
       responses:
         200:
-          description: Switch already exists
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  exists:
-                    type: string
-                required:
-                  - exists
+          description: OK
         default:
           description: Internal server error
         201:
@@ -706,8 +840,11 @@ paths:
                 properties:
                   created:
                     type: string
+                  id:
+                    type: string
                 required:
                   - created
+                  - id
         400:
           description: Invalid JSON
           content:
@@ -720,18 +857,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
-  /switches/{name}:
+  /switches/{id}:
     get:
       tags:
         - Switches
-      summary: Get virtual switch details
-      description: Returns detailed information about a specific virtual switch
+      summary: Get virtual switch details by Id
+      description: Returns detailed information about a specific virtual switch by its GUID
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
+          name: id
       responses:
         200:
           description: Virtual switch details
@@ -757,13 +894,13 @@ paths:
       tags:
         - Switches
       summary: Update a virtual switch
-      description: Updates the notes field of an existing virtual switch
+      description: Updates the notes field of an existing virtual switch by Id
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
+          name: id
       requestBody:
         content:
           application/json:
@@ -806,13 +943,13 @@ paths:
       tags:
         - Switches
       summary: Delete a virtual switch
-      description: Deletes a virtual switch
+      description: Deletes a virtual switch by Id
       parameters:
-        - name: name
+        - required: true
           schema:
             type: string
-          required: true
           in: path
+          name: id
       responses:
         200:
           description: Switch deleted successfully
@@ -835,6 +972,48 @@ paths:
                 $ref: '#/components/schemas/ErrorSchema'
         500:
           description: Failed to delete switch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+  /switches/by-name/{name}:
+    get:
+      tags:
+        - Switches
+      summary: Get switches by name
+      description: Returns an array of virtual switches matching the given name
+      parameters:
+        - required: true
+          schema:
+            type: string
+          in: path
+          name: name
+      responses:
+        200:
+          description: Array of switches with matching name
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    Id:
+                      type: string
+                    Name:
+                      type: string
+                    SwitchType:
+                      type: string
+                    Notes:
+                      type: string
+                  required:
+                    - Id
+                    - Name
+                    - SwitchType
+        default:
+          description: Internal server error
+        500:
+          description: Failed to get switches by name
           content:
             application/json:
               schema:
@@ -870,6 +1049,8 @@ components:
     VmSchema:
       type: object
       properties:
+        Id:
+          type: string
         Name:
           type: string
         State:
@@ -881,6 +1062,7 @@ components:
         Uptime:
           type: string
       required:
+        - Id
         - Name
         - State
         - CPUUsage
@@ -949,6 +1131,8 @@ components:
     SwitchSchema:
       type: object
       properties:
+        Id:
+          type: string
         Name:
           type: string
         SwitchType:
@@ -960,6 +1144,7 @@ components:
         Notes:
           type: string
       required:
+        - Id
         - Name
         - SwitchType
     SwitchCreateSchema:

--- a/tests/run-api-tests.ps1
+++ b/tests/run-api-tests.ps1
@@ -1,0 +1,294 @@
+# API test script - Full scenario against a running Hyper-V API server
+# Usage: .\tests\run-api-tests.ps1 [-BaseUrl <url>] [-VmDiskPath <path>]
+# Prerequisite: Start the API server (e.g. .\src\server.ps1) before running.
+
+param(
+    [string]$BaseUrl = 'http://localhost:8080',
+    [string]$VmDiskPath = 'C:\ProgramData\hvo-api-test'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Naming pattern: hvo-test-{type}-<YYYYMMDDHHmm> (low conflict, clearly test-related)
+$runTimestamp = Get-Date -Format 'yyyyMMddHHmm'
+$testSwitchName = "hvo-test-switch-$runTimestamp"
+$testVmName = "hvo-test-vm-$runTimestamp"
+
+$reportLines = [System.Collections.ArrayList]@()
+$failedTests = [System.Collections.ArrayList]@()
+$createdResourceNames = [System.Collections.ArrayList]@()
+$totalTests = 0
+$passedTests = 0
+$script:SwitchId = $null
+$script:VmId = $null
+
+function Add-Report {
+    param([string]$Text, [string]$Indent = '')
+    $null = $reportLines.Add("$Indent$Text")
+    Write-Host "$Indent$Text"
+}
+
+function Invoke-ApiRequest {
+    param(
+        [string]$Method,
+        [string]$Path,
+        [int[]]$ExpectedStatus = @(200),
+        [hashtable]$Body = $null,
+        [string]$TestName = "$Method $Path"
+    )
+    $url = "$BaseUrl$Path"
+    $headers = @{ 'Accept' = 'application/json'; 'Content-Type' = 'application/json' }
+    $params = @{
+        Uri             = $url
+        Method          = $Method
+        Headers         = $headers
+        UseBasicParsing = $true
+        TimeoutSec      = 30
+    }
+    if ($Body) {
+        $params.Body = ($Body | ConvertTo-Json -Compress -Depth 10)
+    }
+    try {
+        $response = Invoke-WebRequest @params -SkipHttpErrorCheck
+        $content = $response.Content
+        try {
+            $json = $response.Content | ConvertFrom-Json
+        } catch {
+            $json = $null
+        }
+        $ok = $response.StatusCode -in $ExpectedStatus
+        $script:totalTests++
+        if ($ok) { $script:passedTests++ }
+        return @{
+            Success = $ok
+            StatusCode = $response.StatusCode
+            Content = $content
+            Json = $json
+            TestName = $TestName
+        }
+    } catch {
+        $script:totalTests++
+        return @{
+            Success = $false
+            StatusCode = $null
+            Content = $_.Exception.Message
+            Json = $null
+            TestName = $TestName
+        }
+    }
+}
+
+function Add-TestResult {
+    param(
+        [hashtable]$Result,
+        [string]$Phase
+    )
+    $status = if ($Result.Success) { 'OK' } else { 'FAIL' }
+    Add-Report "  [$status] $($Result.TestName) -> $($Result.StatusCode)" "  "
+    if (-not $Result.Success) {
+        $null = $failedTests.Add(@{ Phase = $Phase; Result = $Result })
+        $preview = if ($Result.Content.Length -gt 200) { $Result.Content.Substring(0, 200) + '...' } else { $Result.Content }
+        Add-Report "      Response: $preview" "  "
+    }
+    return $Result
+}
+
+# ----- Confirmation and health check -----
+Add-Report "=== Hyper-V API - Tests de scenario complet ===" ""
+Add-Report "Base URL: $BaseUrl" ""
+Add-Report "Ressources de test: $testSwitchName, $testVmName" ""
+Add-Report ""
+
+Write-Host "Le serveur API doit etre demarre (ex: .\src\server.ps1)." -ForegroundColor Yellow
+$confirm = Read-Host "Le serveur API est-il demarre sur $BaseUrl ? (O/N)"
+if ($confirm -notmatch '^[oOyY]') {
+    Add-Report "Annule par l'utilisateur." ""
+    exit 0
+}
+
+$healthResult = Invoke-ApiRequest -Method Get -Path '/health' -ExpectedStatus 200 -TestName 'GET /health'
+if (-not $healthResult.Success) {
+    Add-Report "ERREUR: Le serveur ne repond pas sur $BaseUrl (GET /health a echoue)." ""
+    Add-Report "Demarrez le serveur avec: .\src\server.ps1" ""
+    exit 1
+}
+Add-Report "[OK] Serveur accessible (GET /health -> $($healthResult.StatusCode))" ""
+Add-Report ""
+
+$startTime = Get-Date
+
+# ========== Phase 1: Basic ==========
+Add-Report "--- Phase 1: Health et documentation ---" ""
+
+$r = Invoke-ApiRequest -Method Get -Path '/openapi.json' -ExpectedStatus 200 -TestName 'GET /openapi.json'
+Add-TestResult -Result $r -Phase 'Phase1' | Out-Null
+if ($r.Success -and $r.Json) {
+    $hasOpenApi = $null -ne ($r.Json.psobject.Properties | Where-Object { $_.Name -eq 'openapi' -or $_.Name -eq 'swagger' })
+    if (-not $hasOpenApi) {
+        $r.Success = $false
+        $r.Content = 'Response is not a valid OpenAPI document (missing openapi/swagger field)'
+        $script:passedTests--
+        $null = $failedTests.Add(@{ Phase = 'Phase1'; Result = $r })
+    }
+}
+
+# ========== Phase 2: Switches ==========
+Add-Report "" ""
+Add-Report "--- Phase 2: Switches ---" ""
+
+$r = Invoke-ApiRequest -Method Get -Path '/switches' -ExpectedStatus 200 -TestName 'GET /switches'
+Add-TestResult -Result $r -Phase 'Phase2' | Out-Null
+
+$bodySwitch = @{
+    name = $testSwitchName
+    type = 'Internal'
+    notes = 'hvo-api-test'
+}
+$r = Invoke-ApiRequest -Method Post -Path '/switches' -Body $bodySwitch -ExpectedStatus 201 -TestName 'POST /switches (create)'
+Add-TestResult -Result $r -Phase 'Phase2' | Out-Null
+if ($r.Success -and $r.Json.id) {
+    $script:SwitchId = $r.Json.id
+    $null = $createdResourceNames.Add("Switch: $testSwitchName (Id: $($script:SwitchId))")
+}
+
+if ($script:SwitchId) {
+    $r = Invoke-ApiRequest -Method Get -Path "/switches/$($script:SwitchId)" -ExpectedStatus 200 -TestName 'GET /switches/:id'
+    Add-TestResult -Result $r -Phase 'Phase2' | Out-Null
+
+        $encodedName = [uri]::EscapeDataString($testSwitchName)
+    $r = Invoke-ApiRequest -Method Get -Path "/switches/by-name/$encodedName" -ExpectedStatus 200 -TestName 'GET /switches/by-name/:name'
+    Add-TestResult -Result $r -Phase 'Phase2' | Out-Null
+
+    $r = Invoke-ApiRequest -Method Put -Path "/switches/$($script:SwitchId)" -Body @{ notes = 'hvo-api-test-updated' } -ExpectedStatus 200 -TestName 'PUT /switches/:id'
+    Add-TestResult -Result $r -Phase 'Phase2' | Out-Null
+}
+
+# ========== Phase 3: VMs (full scenario) ==========
+Add-Report "" ""
+Add-Report "--- Phase 3: VMs ---" ""
+
+$r = Invoke-ApiRequest -Method Get -Path '/vms' -ExpectedStatus 200 -TestName 'GET /vms'
+Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+
+if (-not $script:SwitchId) {
+    Add-Report "  [SKIP] Creation VM ignoree (switch non cree)." "  "
+} else {
+    $bodyVm = @{
+        name       = $testVmName
+        memoryMB   = 512
+        vcpu       = 1
+        diskPath   = $VmDiskPath
+        diskGB     = 2
+        switchName = $testSwitchName
+    }
+    $r = Invoke-ApiRequest -Method Post -Path '/vms' -Body $bodyVm -ExpectedStatus 201 -TestName 'POST /vms (create)'
+    Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+    if ($r.Success -and $r.Json.id) {
+        $script:VmId = $r.Json.id
+        $null = $createdResourceNames.Add("VM: $testVmName (Id: $($script:VmId))")
+    }
+
+    if ($script:VmId) {
+        $r = Invoke-ApiRequest -Method Get -Path "/vms/$($script:VmId)" -ExpectedStatus 200 -TestName 'GET /vms/:id'
+        Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+
+        $encodedVmName = [uri]::EscapeDataString($testVmName)
+        $r = Invoke-ApiRequest -Method Get -Path "/vms/by-name/$encodedVmName" -ExpectedStatus 200 -TestName 'GET /vms/by-name/:name'
+        Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+
+        $r = Invoke-ApiRequest -Method Post -Path "/vms/$($script:VmId)/start" -ExpectedStatus 200 -TestName 'POST /vms/:id/start'
+        Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+
+        Start-Sleep -Seconds 3
+        $r = Invoke-ApiRequest -Method Get -Path "/vms/$($script:VmId)" -ExpectedStatus 200 -TestName 'GET /vms/:id (state Running)'
+        if ($r.Success -and $r.Json.State -ne 'Running') {
+            $r.Success = $false
+            $r.Content = "Expected State=Running, got $($r.Json.State)"
+            $null = $failedTests.Add(@{ Phase = 'Phase3'; Result = $r })
+        }
+        $script:totalTests++
+        if ($r.Success) { $script:passedTests++ }
+        Add-Report "  [$(if ($r.Success) { 'OK' } else { 'FAIL' })] $($r.TestName) -> $($r.StatusCode)" "  "
+        if (-not $r.Success) { Add-Report "      Response: $($r.Content)" "  " }
+
+        $r = Invoke-ApiRequest -Method Post -Path "/vms/$($script:VmId)/stop" -Body @{ force = $true } -ExpectedStatus 200 -TestName 'POST /vms/:id/stop'
+        Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+
+        Start-Sleep -Seconds 2
+        $r = Invoke-ApiRequest -Method Get -Path "/vms/$($script:VmId)" -ExpectedStatus 200 -TestName 'GET /vms/:id (state Off)'
+        if ($r.Success -and $r.Json.State -ne 'Off') {
+            $r.Success = $false
+            $r.Content = "Expected State=Off, got $($r.Json.State)"
+            $null = $failedTests.Add(@{ Phase = 'Phase3'; Result = $r })
+        }
+        $script:totalTests++
+        if ($r.Success) { $script:passedTests++ }
+        Add-Report "  [$(if ($r.Success) { 'OK' } else { 'FAIL' })] $($r.TestName) -> $($r.StatusCode)" "  "
+        if (-not $r.Success) { Add-Report "      Response: $($r.Content)" "  " }
+
+        $r = Invoke-ApiRequest -Method Get -Path "/vms/$($script:VmId)/network-adapters" -ExpectedStatus 200 -TestName 'GET /vms/:id/network-adapters'
+        Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+
+        $r = Invoke-ApiRequest -Method Put -Path "/vms/$($script:VmId)" -Body @{ memoryMB = 512; vcpu = 1 } -ExpectedStatus 200 -TestName 'PUT /vms/:id'
+        Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+
+        $r = Invoke-ApiRequest -Method Delete -Path "/vms/$($script:VmId)" -ExpectedStatus 200 -TestName 'DELETE /vms/:id'
+        Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+    }
+
+    # Delete test switch (after VM so VM is gone first)
+    if ($script:SwitchId) {
+        $r = Invoke-ApiRequest -Method Delete -Path "/switches/$($script:SwitchId)" -ExpectedStatus 200 -TestName 'DELETE /switches/:id'
+        Add-TestResult -Result $r -Phase 'Phase2' | Out-Null
+    }
+}
+
+# ----- Report -----
+$endTime = Get-Date
+$duration = $endTime - $startTime
+Add-Report "" ""
+Add-Report "=== Rapport ===" ""
+Add-Report "Date/heure: $($endTime.ToString('yyyy-MM-dd HH:mm:ss'))" ""
+Add-Report "Duree: $($duration.TotalSeconds.ToString('F1')) s" ""
+Add-Report "Resultat: $passedTests / $totalTests tests reussis" ""
+if ($failedTests.Count -gt 0) {
+    Add-Report "" ""
+    Add-Report "--- Echecs ---" ""
+    foreach ($f in $failedTests) {
+        Add-Report "  - $($f.Result.TestName)" ""
+        Add-Report "    HTTP $($f.Result.StatusCode) | $($f.Result.Content)" ""
+    }
+    Add-Report "" ""
+    Add-Report "--- Remise en condition initiale Hyper-V ---" ""
+    Add-Report "Si des ressources de test sont restees, supprimez-les avec PowerShell (en administrateur):" ""
+    Add-Report "" ""
+    Add-Report "  # Supprimer les VMs de test (nom commencant par hvo-test-vm-)" ""
+    Add-Report "  Get-VM | Where-Object { `$_.Name -like 'hvo-test-vm-*' } | Stop-VM -Force -ErrorAction SilentlyContinue; Get-VM | Where-Object { `$_.Name -like 'hvo-test-vm-*' } | Remove-VM -Force" ""
+    Add-Report "" ""
+    Add-Report "  # Supprimer les switches de test (nom commencant par hvo-test-switch-)" ""
+    Add-Report "  Get-VMSwitch | Where-Object { `$_.Name -like 'hvo-test-switch-*' } | Remove-VMSwitch -Force" ""
+    Add-Report "" ""
+    Add-Report "  # Lister les ressources restantes (optionnel)" ""
+    Add-Report "  Get-VM | Where-Object { `$_.Name -like 'hvo-test-*' }; Get-VMSwitch | Where-Object { `$_.Name -like 'hvo-test-*' }" ""
+    Add-Report "" ""
+    if ($createdResourceNames.Count -gt 0) {
+        Add-Report "Ressources creees pendant ce run (a nettoyer si besoin):" ""
+        foreach ($name in $createdResourceNames) {
+            Add-Report "  - $name" ""
+        }
+    }
+}
+
+$reportDir = Join-Path $PSScriptRoot 'reports'
+if (-not (Test-Path $reportDir)) {
+    New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+}
+$reportFile = Join-Path $reportDir "api-test-report-$runTimestamp.txt"
+$reportLines -join "`n" | Set-Content -Path $reportFile -Encoding UTF8
+Add-Report "" ""
+Add-Report "Rapport enregistre: $reportFile" ""
+
+if ($failedTests.Count -gt 0) {
+    exit 1
+}
+exit 0

--- a/tests/unit/HvoSwitch.Tests.ps1
+++ b/tests/unit/HvoSwitch.Tests.ps1
@@ -2,10 +2,10 @@
 # Uses InModuleScope to test within the module context and allow mocks to work
 
 BeforeAll {
-    # Créer des stubs pour les cmdlets Hyper-V si elles n'existent pas (ex: WSL, Linux)
-    # Cela permet à Pester de mocker ces commandes même sans le module Hyper-V
+    # Create stubs for Hyper-V cmdlets when they are not present (e.g. WSL, Linux)
+    # This allows Pester to mock these commands even without the Hyper-V module
     if (-not (Get-Command Get-VMSwitch -ErrorAction SilentlyContinue)) {
-        function global:Get-VMSwitch { param($Name, $ErrorAction) }
+        function global:Get-VMSwitch { param($Name, $Id, $ErrorAction) }
     }
     if (-not (Get-Command New-VMSwitch -ErrorAction SilentlyContinue)) {
         function global:New-VMSwitch { param($Name, $SwitchType, $NetAdapterName, $AllowManagementOS) }
@@ -22,221 +22,153 @@ BeforeAll {
 }
 
 InModuleScope HvoSwitch {
+    $script:testSwitchGuid = [guid]'bbbbbbbb-cccc-dddd-eeee-ffffffffffff'
+
     Describe "New-HvoSwitch" {
-        Context "When the switch already exists" {
-            It "Should return an object with Exists = true" {
-                # Arrange
-                $switchName = "existing-switch"
-                $mockSwitch = [PSCustomObject]@{
-                    Name = $switchName
-                }
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
-                Mock New-VMSwitch -MockWith { }
-
-                # Act
-                $result = New-HvoSwitch -Name $switchName -Type "Internal"
-
-                # Assert
-                $result | Should -Not -BeNullOrEmpty
-                $result.Exists | Should -Be $true
-                $result.Name | Should -Be $switchName
-                Should -Invoke Get-VMSwitch -Exactly -Times 1 -ParameterFilter { $Name -eq $switchName }
-                Should -Not -Invoke New-VMSwitch
-            }
-        }
-
-        Context "When the switch does not exist" {
-            It "Should create an Internal type switch" {
-                # Arrange
+        Context "When creating a new switch" {
+            It "Should create an Internal type switch and return Name and Id" {
                 $switchName = "new-internal-switch"
-                $mockSwitch = [PSCustomObject]@{
-                    Name = $switchName
-                }
+                $mockSwitch = [PSCustomObject]@{ Name = $switchName; Id = $script:testSwitchGuid }
 
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
                 Mock New-VMSwitch -ParameterFilter {
                     $Name -eq $switchName -and $SwitchType -eq "Internal"
                 } -MockWith { return $mockSwitch }
 
-                # Act
                 $result = New-HvoSwitch -Name $switchName -Type "Internal"
 
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
-                $result.Exists | Should -Be $false
                 $result.Name | Should -Be $switchName
+                $result.Id | Should -Be $script:testSwitchGuid.ToString()
                 Should -Invoke New-VMSwitch -Exactly -Times 1 -ParameterFilter {
                     $Name -eq $switchName -and $SwitchType -eq "Internal"
                 }
             }
 
             It "Should create a Private type switch" {
-                # Arrange
                 $switchName = "new-private-switch"
-                $mockSwitch = [PSCustomObject]@{
-                    Name = $switchName
-                }
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
-                Mock New-VMSwitch -ParameterFilter {
-                    $Name -eq $switchName -and $SwitchType -eq "Private"
-                } -MockWith { return $mockSwitch }
-
-                # Act
+                $mockSwitch = [PSCustomObject]@{ Name = $switchName; Id = $script:testSwitchGuid }
+                Mock New-VMSwitch -ParameterFilter { $Name -eq $switchName -and $SwitchType -eq "Private" } -MockWith { return $mockSwitch }
                 $result = New-HvoSwitch -Name $switchName -Type "Private"
-
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
-                $result.Exists | Should -Be $false
                 $result.Name | Should -Be $switchName
-                Should -Invoke New-VMSwitch -Exactly -Times 1 -ParameterFilter {
-                    $Name -eq $switchName -and $SwitchType -eq "Private"
-                }
+                $result.Id | Should -Not -BeNullOrEmpty
+                Should -Invoke New-VMSwitch -Exactly -Times 1 -ParameterFilter { $Name -eq $switchName -and $SwitchType -eq "Private" }
             }
 
             It "Should create an External type switch with NetAdapterName" {
-                # Arrange
                 $switchName = "new-external-switch"
                 $netAdapterName = "Ethernet"
-                $mockSwitch = [PSCustomObject]@{
-                    Name = $switchName
-                }
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+                $mockSwitch = [PSCustomObject]@{ Name = $switchName; Id = $script:testSwitchGuid }
                 Mock New-VMSwitch -ParameterFilter {
-                    $Name -eq $switchName -and
-                    $NetAdapterName -eq $netAdapterName -and
-                    $AllowManagementOS -eq $true
+                    $Name -eq $switchName -and $NetAdapterName -eq $netAdapterName -and $AllowManagementOS -eq $true
                 } -MockWith { return $mockSwitch }
-
-                # Act
                 $result = New-HvoSwitch -Name $switchName -Type "External" -NetAdapterName $netAdapterName
-
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
-                $result.Exists | Should -Be $false
                 $result.Name | Should -Be $switchName
                 Should -Invoke New-VMSwitch -Exactly -Times 1 -ParameterFilter {
-                    $Name -eq $switchName -and
-                    $NetAdapterName -eq $netAdapterName -and
-                    $AllowManagementOS -eq $true
+                    $Name -eq $switchName -and $NetAdapterName -eq $netAdapterName -and $AllowManagementOS -eq $true
                 }
             }
 
             It "Should throw an exception if External is created without NetAdapterName" {
-                # Arrange
-                $switchName = "external-switch-no-adapter"
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
-
-                # Act & Assert
-                { New-HvoSwitch -Name $switchName -Type "External" } | Should -Throw "External switch requires -NetAdapterName"
+                { New-HvoSwitch -Name "external-switch-no-adapter" -Type "External" } | Should -Throw "External switch requires -NetAdapterName"
             }
 
             It "Should apply notes if provided" {
-                # Arrange
                 $switchName = "switch-with-notes"
                 $notes = "Test switch notes"
-                $mockSwitch = [PSCustomObject]@{
-                    Name = $switchName
-                }
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+                $mockSwitch = [PSCustomObject]@{ Name = $switchName; Id = $script:testSwitchGuid }
                 Mock New-VMSwitch -MockWith { return $mockSwitch }
                 Mock Set-VMSwitch -MockWith { }
-
-                # Act
                 $result = New-HvoSwitch -Name $switchName -Type "Internal" -Notes $notes
-
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
-                Should -Invoke Set-VMSwitch -Exactly -Times 1 -ParameterFilter {
-                    $Name -eq $switchName -and $Notes -eq $notes
-                }
+                Should -Invoke Set-VMSwitch -Exactly -Times 1 -ParameterFilter { $Name -eq $switchName -and $Notes -eq $notes }
             }
         }
     }
 
     Describe "Get-HvoSwitch" {
         Context "When the switch exists" {
-            It "Should return the switch" {
-                # Arrange
-                $switchName = "test-switch"
+            It "Should return the switch with Id" {
+                $switchId = $script:testSwitchGuid
                 $mockSwitch = [PSCustomObject]@{
-                    Name = $switchName
+                    Id = $switchId
+                    Name = "test-switch"
                     SwitchType = "Internal"
+                    Notes = "notes"
                 }
+                $mockSwitch.SwitchType | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return "Internal" } -Force
 
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $mockSwitch }
 
-                # Act
-                $result = Get-HvoSwitch -Name $switchName
+                $result = Get-HvoSwitch -Id $switchId.ToString()
 
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
-                $result.Name | Should -Be $switchName
-                Should -Invoke Get-VMSwitch -Exactly -Times 1 -ParameterFilter { $Name -eq $switchName }
+                $result.Id | Should -Be $switchId.ToString()
+                $result.Name | Should -Be "test-switch"
+                Should -Invoke Get-VMSwitch -Exactly -Times 1 -ParameterFilter { $Id -eq $switchId }
             }
         }
 
         Context "When the switch does not exist" {
             It "Should return null" {
-                # Arrange
-                $switchName = "non-existent-switch"
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
-
-                # Act
-                $result = Get-HvoSwitch -Name $switchName
-
-                # Assert
+                $switchId = [guid]'00000000-0000-0000-0000-000000000001'
+                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $null }
+                $result = Get-HvoSwitch -Id $switchId.ToString()
                 $result | Should -BeNullOrEmpty
             }
         }
     }
 
+    Describe "Get-HvoSwitchByName" {
+        It "Should return an empty array when no switch matches" {
+            Mock Get-VMSwitch -MockWith { return @() }
+            $result = Get-HvoSwitchByName -Name "no-such-switch"
+            if ($null -eq $result) { $result = @() }
+            $result.Count | Should -Be 0
+        }
+
+        It "Should return switches matching the name" {
+            $guid = [guid]::NewGuid()
+            $mockSwitch = [PSCustomObject]@{ Id = $guid; Name = "lan"; SwitchType = "Internal"; Notes = $null }
+            $mockSwitch.SwitchType | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return "Internal" } -Force
+            Mock Get-VMSwitch -MockWith { return $mockSwitch }
+            $result = Get-HvoSwitchByName -Name "lan"
+            $result | Should -Not -BeNullOrEmpty
+            $result.Count | Should -Be 1
+            $result[0].Id | Should -Be $guid.ToString()
+            $result[0].Name | Should -Be "lan"
+        }
+    }
+
     Describe "Get-HvoSwitches" {
-        It "Should return the list of all switches" {
-            # Arrange
+        It "Should return the list of all switches with Id" {
+            $guid1 = [guid]::NewGuid()
+            $guid2 = [guid]::NewGuid()
             $mockSwitches = @(
-                [PSCustomObject]@{
-                    Name = "switch1"
-                    SwitchType = "Internal"
-                    Notes = "Notes 1"
-                },
-                [PSCustomObject]@{
-                    Name = "switch2"
-                    SwitchType = "External"
-                    Notes = "Notes 2"
-                }
+                [PSCustomObject]@{ Id = $guid1; Name = "switch1"; SwitchType = "Internal"; Notes = "Notes 1" },
+                [PSCustomObject]@{ Id = $guid2; Name = "switch2"; SwitchType = "External"; Notes = "Notes 2" }
             )
+            $mockSwitches[0].SwitchType | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return "Internal" } -Force
+            $mockSwitches[1].SwitchType | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return "External" } -Force
 
             Mock Get-VMSwitch -MockWith { return $mockSwitches }
 
-            # Act
             $result = Get-HvoSwitches
 
-            # Assert
             $result | Should -Not -BeNullOrEmpty
             $result.Count | Should -Be 2
+            $result[0].Id | Should -Be $guid1.ToString()
             $result[0].Name | Should -Be "switch1"
+            $result[1].Id | Should -Be $guid2.ToString()
             $result[1].Name | Should -Be "switch2"
             Should -Invoke Get-VMSwitch -Exactly -Times 1
         }
 
         It "Should return an empty array if there are no switches" {
-            # Arrange
             Mock Get-VMSwitch -MockWith { return @() }
-
-            # Act
             $result = Get-HvoSwitches
-
-            # Assert
-            # Select-Object on an empty array may return $null, so we accept both cases
-            if ($null -eq $result) {
-                $result = @()
-            }
+            if ($null -eq $result) { $result = @() }
             $result.Count | Should -Be 0
         }
     }
@@ -244,16 +176,10 @@ InModuleScope HvoSwitch {
     Describe "Set-HvoSwitch" {
         Context "When the switch does not exist" {
             It "Should return Updated = false with an error" {
-                # Arrange
-                $switchName = "non-existent-switch"
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+                $switchId = [guid]'00000000-0000-0000-0000-000000000001'
+                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $null }
                 Mock Set-VMSwitch -MockWith { }
-
-                # Act
-                $result = Set-HvoSwitch -Name $switchName -Notes "New notes"
-
-                # Assert
+                $result = Set-HvoSwitch -Id $switchId.ToString() -Notes "New notes"
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $false
                 $result.Error | Should -Be "Switch not found"
@@ -263,62 +189,40 @@ InModuleScope HvoSwitch {
 
         Context "When the switch exists" {
             It "Should update notes" {
-                # Arrange
-                $switchName = "existing-switch"
+                $switchId = $script:testSwitchGuid
                 $newNotes = "Updated notes"
-                $mockSwitch = [PSCustomObject]@{
-                    Name = $switchName
-                }
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "existing-switch" }
+                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $mockSwitch }
                 Mock Set-VMSwitch -MockWith { }
-
-                # Act
-                $result = Set-HvoSwitch -Name $switchName -Notes $newNotes
-
-                # Assert
+                $result = Set-HvoSwitch -Id $switchId.ToString() -Notes $newNotes
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $true
-                $result.Name | Should -Be $switchName
+                $result.Name | Should -Be "existing-switch"
                 Should -Invoke Set-VMSwitch -Exactly -Times 1 -ParameterFilter {
-                    $Name -eq $switchName -and $Notes -eq $newNotes
+                    $Name -eq "existing-switch" -and $Notes -eq $newNotes
                 }
             }
 
             It "Should return Updated = true even without modification if the switch exists" {
-                # Arrange
-                $switchName = "existing-switch"
-                $mockSwitch = [PSCustomObject]@{
-                    Name = $switchName
-                }
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                $switchId = $script:testSwitchGuid
+                $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "existing-switch" }
+                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $mockSwitch }
                 Mock Set-VMSwitch -MockWith { }
-
-                # Act
-                $result = Set-HvoSwitch -Name $switchName
-
-                # Assert
+                $result = Set-HvoSwitch -Id $switchId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $true
-                $result.Name | Should -Be $switchName
+                $result.Name | Should -Be "existing-switch"
                 Should -Not -Invoke Set-VMSwitch
             }
         }
 
         Context "When an error occurs" {
             It "Should propagate the exception" {
-                # Arrange
-                $switchName = "switch-with-error"
-                $mockSwitch = [PSCustomObject]@{
-                    Name = $switchName
-                }
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                $switchId = $script:testSwitchGuid
+                $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "switch-with-error" }
+                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $mockSwitch }
                 Mock Set-VMSwitch -MockWith { throw "Test error" }
-
-                # Act & Assert
-                { Set-HvoSwitch -Name $switchName -Notes "Test" } | Should -Throw
+                { Set-HvoSwitch -Id $switchId.ToString() -Notes "Test" } | Should -Throw
             }
         }
     }
@@ -326,16 +230,10 @@ InModuleScope HvoSwitch {
     Describe "Remove-HvoSwitch" {
         Context "When the switch does not exist" {
             It "Should return false" {
-                # Arrange
-                $switchName = "non-existent-switch"
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $null }
+                $switchId = [guid]'00000000-0000-0000-0000-000000000001'
+                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $null }
                 Mock Remove-VMSwitch -MockWith { }
-
-                # Act
-                $result = Remove-HvoSwitch -Name $switchName
-
-                # Assert
+                $result = Remove-HvoSwitch -Id $switchId.ToString()
                 $result | Should -Be $false
                 Should -Not -Invoke Remove-VMSwitch
             }
@@ -343,37 +241,21 @@ InModuleScope HvoSwitch {
 
         Context "When the switch exists" {
             It "Should remove the switch" {
-                # Arrange
-                $switchName = "existing-switch"
-                $mockSwitch = [PSCustomObject]@{
-                    Name = $switchName
-                }
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                $switchId = $script:testSwitchGuid
+                $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "existing-switch" }
+                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $mockSwitch }
                 Mock Remove-VMSwitch -MockWith { }
-
-                # Act
-                $result = Remove-HvoSwitch -Name $switchName
-
-                # Assert
+                $result = Remove-HvoSwitch -Id $switchId.ToString()
                 $result | Should -Be $true
-                Should -Invoke Remove-VMSwitch -Exactly -Times 1
+                Should -Invoke Remove-VMSwitch -Exactly -Times 1 -ParameterFilter { $Name -eq "existing-switch" }
             }
 
             It "Should return false if deletion fails" {
-                # Arrange
-                $switchName = "switch-with-error"
-                $mockSwitch = [PSCustomObject]@{
-                    Name = $switchName
-                }
-
-                Mock Get-VMSwitch -ParameterFilter { $Name -eq $switchName } -MockWith { return $mockSwitch }
+                $switchId = $script:testSwitchGuid
+                $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "switch-with-error" }
+                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $mockSwitch }
                 Mock Remove-VMSwitch -MockWith { throw "Cannot remove switch" }
-
-                # Act
-                $result = Remove-HvoSwitch -Name $switchName
-
-                # Assert
+                $result = Remove-HvoSwitch -Id $switchId.ToString()
                 $result | Should -Be $false
             }
         }

--- a/tests/unit/HvoVm.Tests.ps1
+++ b/tests/unit/HvoVm.Tests.ps1
@@ -2,10 +2,10 @@
 # Uses InModuleScope to test within the module context and allow mocks to work
 
 BeforeAll {
-    # Créer des stubs pour les cmdlets Hyper-V si elles n'existent pas (ex: WSL, Linux)
-    # Cela permet à Pester de mocker ces commandes même sans le module Hyper-V
+    # Create stubs for Hyper-V cmdlets when they are not present (e.g. WSL, Linux)
+    # This allows Pester to mock these commands even without the Hyper-V module
     if (-not (Get-Command Get-VM -ErrorAction SilentlyContinue)) {
-        function global:Get-VM { param($Name, $ErrorAction) }
+        function global:Get-VM { param($Name, $Id, $ErrorAction) }
     }
     if (-not (Get-Command New-VM -ErrorAction SilentlyContinue)) {
         function global:New-VM { param($Name, $MemoryStartupBytes, $Generation, $VHDPath, $SwitchName) }
@@ -47,13 +47,13 @@ BeforeAll {
         function global:Remove-VMDvdDrive { param($VMName, $ControllerNumber, $ControllerLocation, $ErrorAction) }
     }
     if (-not (Get-Command Get-VMNetworkAdapter -ErrorAction SilentlyContinue)) {
-        function global:Get-VMNetworkAdapter { param($VMName, $ErrorAction) }
+        function global:Get-VMNetworkAdapter { param($VMName, $VM, $ErrorAction) }
     }
     if (-not (Get-Command Add-VMNetworkAdapter -ErrorAction SilentlyContinue)) {
-        function global:Add-VMNetworkAdapter { param($VMName, $SwitchName, $ErrorAction) }
+        function global:Add-VMNetworkAdapter { param($VMName, $VM, $SwitchName, $ErrorAction) }
     }
     if (-not (Get-Command Remove-VMNetworkAdapter -ErrorAction SilentlyContinue)) {
-        function global:Remove-VMNetworkAdapter { param($VMName, $Confirm, $ErrorAction) }
+        function global:Remove-VMNetworkAdapter { param($VMName, $VMNetworkAdapter, $Confirm, $ErrorAction) }
     }
     if (-not (Get-Command Get-VMSnapshot -ErrorAction SilentlyContinue)) {
         function global:Get-VMSnapshot { param($VMName, $ErrorAction) }
@@ -73,43 +73,21 @@ BeforeAll {
 }
 
 InModuleScope HvoVm {
+    $script:testVmGuid = [guid]'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
     Describe "New-HvoVm" {
-        Context "When the VM already exists" {
-            It "Should return an object with Exists = true" {
-                # Arrange
-                $vmName = "test-vm-existing"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock New-VM -MockWith { }
-
-                # Act
-                $result = New-HvoVm -Name $vmName -MemoryMB 1024 -Vcpu 2 -DiskPath "/tmp/VMs" -DiskGB 20 -SwitchName "test-switch"
-
-                # Assert
-                $result | Should -Not -BeNullOrEmpty
-                $result.Exists | Should -Be $true
-                $result.Name | Should -Be $vmName
-                Should -Invoke Get-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
-                Should -Not -Invoke New-VM
-            }
-        }
-
-        Context "When the VM does not exist" {
-            It "Should create a new VM with the provided parameters" {
+        Context "When creating a new VM" {
+            It "Should create a new VM and return Name and Id" {
                 # Arrange
                 $vmName = "test-vm-new"
                 $diskPath = "/tmp/TestVMs"
                 $vhdPath = Join-Path $diskPath "$vmName.vhdx"
                 $switchName = "test-switch"
-
                 $mockVm = [PSCustomObject]@{
                     Name = $vmName
+                    Id   = $script:testVmGuid
                 }
 
-                Mock Get-VM -MockWith { return $null }
                 Mock Test-Path -ParameterFilter { $Path -eq $diskPath } -MockWith { return $false }
                 Mock New-Item -MockWith { return [PSCustomObject]@{ FullName = $diskPath } }
                 Mock Test-Path -ParameterFilter { $Path -eq $vhdPath } -MockWith { return $false }
@@ -122,8 +100,8 @@ InModuleScope HvoVm {
 
                 # Assert
                 $result | Should -Not -BeNullOrEmpty
-                $result.Exists | Should -Be $false
                 $result.Name | Should -Be $vmName
+                $result.Id | Should -Be $script:testVmGuid.ToString()
                 Should -Invoke New-VM -Exactly -Times 1 -ParameterFilter {
                     $Name -eq $vmName -and
                     $MemoryStartupBytes -eq (2048 * 1MB) -and
@@ -136,17 +114,39 @@ InModuleScope HvoVm {
                 }
             }
 
+            It "Should return two different Ids when creating two VMs with the same name" {
+                # Arrange: each POST creates a new resource
+                $vmName = "dup-name"
+                $diskPath = "/tmp/VMs"
+                $callCount = 0
+                Mock Test-Path -MockWith { return $true }
+                Mock New-VHD -MockWith { return [PSCustomObject]@{ Path = "test.vhdx" } }
+                Mock New-VM -MockWith {
+                    $callCount++
+                    return [PSCustomObject]@{ Name = $vmName; Id = [guid]::NewGuid() }
+                }
+                Mock Set-VMProcessor -MockWith { }
+
+                # Act: simulate two creates with same name
+                $result1 = New-HvoVm -Name $vmName -MemoryMB 1024 -Vcpu 2 -DiskPath $diskPath -DiskGB 20 -SwitchName "s1"
+                $result2 = New-HvoVm -Name $vmName -MemoryMB 1024 -Vcpu 2 -DiskPath $diskPath -DiskGB 20 -SwitchName "s1"
+
+                # Assert: both have Id; two New-VM calls
+                $result1.Id | Should -Not -BeNullOrEmpty
+                $result2.Id | Should -Not -BeNullOrEmpty
+                Should -Invoke New-VM -Exactly -Times 2
+            }
+
             It "Should create the disk directory if it does not exist" {
                 # Arrange
                 $vmName = "test-vm-new"
                 $diskPath = "/tmp/TestVMs"
 
-                Mock Get-VM -MockWith { return $null }
                 Mock Test-Path -ParameterFilter { $Path -eq $diskPath } -MockWith { return $false }
                 Mock New-Item -MockWith { return [PSCustomObject]@{ FullName = $diskPath } }
                 Mock Test-Path -ParameterFilter { $Path -like "*.vhdx" } -MockWith { return $false }
                 Mock New-VHD -MockWith { return [PSCustomObject]@{ Path = "test.vhdx" } }
-                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName } }
+                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName; Id = $script:testVmGuid } }
                 Mock Set-VMProcessor -MockWith { }
 
                 # Act
@@ -164,11 +164,10 @@ InModuleScope HvoVm {
                 $diskPath = "/tmp/TestVMs"
                 $vhdPath = Join-Path $diskPath "$vmName.vhdx"
 
-                Mock Get-VM -MockWith { return $null }
                 Mock Test-Path -ParameterFilter { $Path -eq $diskPath } -MockWith { return $true }
                 Mock Test-Path -ParameterFilter { $Path -eq $vhdPath } -MockWith { return $false }
                 Mock New-VHD -MockWith { return [PSCustomObject]@{ Path = $vhdPath } }
-                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName } }
+                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName; Id = $script:testVmGuid } }
                 Mock Set-VMProcessor -MockWith { }
 
                 # Act
@@ -183,11 +182,10 @@ InModuleScope HvoVm {
                 $vmName = "test-vm-new"
                 $isoPath = "/tmp/ISOs/test.iso"
 
-                Mock Get-VM -MockWith { return $null }
                 Mock Test-Path -ParameterFilter { $Path -ne $isoPath } -MockWith { return $true }
                 Mock Test-Path -ParameterFilter { $Path -eq $isoPath } -MockWith { return $true }
                 Mock New-VHD -MockWith { return [PSCustomObject]@{ Path = "test.vhdx" } }
-                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName } }
+                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName; Id = $script:testVmGuid } }
                 Mock Set-VMProcessor -MockWith { }
                 Mock Add-VMDvdDrive -MockWith { }
 
@@ -205,11 +203,10 @@ InModuleScope HvoVm {
                 $vmName = "test-vm-new"
                 $isoPath = "/tmp/ISOs/nonexistent.iso"
 
-                Mock Get-VM -MockWith { return $null }
                 Mock Test-Path -ParameterFilter { $Path -ne $isoPath } -MockWith { return $true }
                 Mock Test-Path -ParameterFilter { $Path -eq $isoPath } -MockWith { return $false }
                 Mock New-VHD -MockWith { return [PSCustomObject]@{ Path = "test.vhdx" } }
-                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName } }
+                Mock New-VM -MockWith { return [PSCustomObject]@{ Name = $vmName; Id = $script:testVmGuid } }
                 Mock Set-VMProcessor -MockWith { }
 
                 # Act & Assert
@@ -220,10 +217,12 @@ InModuleScope HvoVm {
 
     Describe "Get-HvoVm" {
         Context "When the VM exists" {
-            It "Should return the VM details" {
+            It "Should return the VM details with Id" {
                 # Arrange
+                $vmId = $script:testVmGuid
                 $vmName = "test-vm"
                 $mockVm = [PSCustomObject]@{
+                    Id = $vmId
                     Name = $vmName
                     State = "Running"
                     CPUUsage = 50
@@ -232,30 +231,31 @@ InModuleScope HvoVm {
                 }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
 
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
 
                 # Act
-                $result = Get-HvoVm -Name $vmName
+                $result = Get-HvoVm -Id $vmId.ToString()
 
                 # Assert
                 $result | Should -Not -BeNullOrEmpty
+                $result.Id | Should -Be $vmId.ToString()
                 $result.Name | Should -Be $vmName
                 $result.State | Should -Be "Running"
                 $result.CPUUsage | Should -Be 50
                 $result.MemoryAssigned | Should -Be 1GB
-                Should -Invoke Get-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+                Should -Invoke Get-VM -Exactly -Times 1 -ParameterFilter { $Id -eq $vmId }
             }
         }
 
         Context "When the VM does not exist" {
             It "Should return null" {
                 # Arrange
-                $vmName = "non-existent-vm"
+                $vmId = [guid]'00000000-0000-0000-0000-000000000001'
 
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $null }
 
                 # Act
-                $result = Get-HvoVm -Name $vmName
+                $result = Get-HvoVm -Id $vmId.ToString()
 
                 # Assert
                 $result | Should -BeNullOrEmpty
@@ -264,27 +264,31 @@ InModuleScope HvoVm {
     }
 
     Describe "Get-HvoVms" {
-        It "Should return the list of all VMs" {
+        It "Should return the list of all VMs with Id" {
             # Arrange
-                $vm1 = [PSCustomObject]@{
-                    Name = "vm1"
-                    State = "Running"
-                    CPUUsage = 30
-                    MemoryAssigned = 512MB
-                    Uptime = New-TimeSpan -Hours 2
-                }
-                $vm1 | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+            $guid1 = [guid]::NewGuid()
+            $guid2 = [guid]::NewGuid()
+            $vm1 = [PSCustomObject]@{
+                Id = $guid1
+                Name = "vm1"
+                State = "Running"
+                CPUUsage = 30
+                MemoryAssigned = 512MB
+                Uptime = New-TimeSpan -Hours 2
+            }
+            $vm1 | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
 
-                $vm2 = [PSCustomObject]@{
-                    Name = "vm2"
-                    State = "Off"
-                    CPUUsage = 0
-                    MemoryAssigned = 0
-                    Uptime = New-TimeSpan
-                }
-                $vm2 | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+            $vm2 = [PSCustomObject]@{
+                Id = $guid2
+                Name = "vm2"
+                State = "Off"
+                CPUUsage = 0
+                MemoryAssigned = 0
+                Uptime = New-TimeSpan
+            }
+            $vm2 | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
 
-                $mockVms = @($vm1, $vm2)
+            $mockVms = @($vm1, $vm2)
 
             Mock Get-VM -MockWith { return $mockVms }
 
@@ -294,7 +298,9 @@ InModuleScope HvoVm {
             # Assert
             $result | Should -Not -BeNullOrEmpty
             $result.Count | Should -Be 2
+            $result[0].Id | Should -Be $guid1.ToString()
             $result[0].Name | Should -Be "vm1"
+            $result[1].Id | Should -Be $guid2.ToString()
             $result[1].Name | Should -Be "vm2"
             Should -Invoke Get-VM -Exactly -Times 1
         }
@@ -307,7 +313,6 @@ InModuleScope HvoVm {
             $result = Get-HvoVms
 
             # Assert
-            # ForEach-Object on an empty array returns $null, so we accept both cases
             if ($null -eq $result) {
                 $result = @()
             }
@@ -315,18 +320,63 @@ InModuleScope HvoVm {
         }
     }
 
+    Describe "Get-HvoVmByName" {
+        It "Should return an empty array when no VM matches the name" {
+            Mock Get-VM -MockWith { return @() }
+
+            $result = Get-HvoVmByName -Name "no-such-vm"
+
+            # Empty array: result may be @() or $null depending on PowerShell
+            if ($null -eq $result) { $result = @() }
+            $result.Count | Should -Be 0
+        }
+
+        It "Should return a single VM when one matches" {
+            $guid = [guid]::NewGuid()
+            $mockVm = [PSCustomObject]@{
+                Id = $guid
+                Name = "single-vm"
+                State = "Off"
+                CPUUsage = 0
+                MemoryAssigned = 0
+                Uptime = New-TimeSpan
+            }
+            $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+            Mock Get-VM -MockWith { return $mockVm }
+
+            $result = Get-HvoVmByName -Name "single-vm"
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.Count | Should -Be 1
+            $result[0].Id | Should -Be $guid.ToString()
+            $result[0].Name | Should -Be "single-vm"
+        }
+
+        It "Should return multiple VMs when several have the same name" {
+            $guid1 = [guid]::NewGuid()
+            $guid2 = [guid]::NewGuid()
+            $vm1 = [PSCustomObject]@{ Id = $guid1; Name = "dup"; State = "Off"; CPUUsage = 0; MemoryAssigned = 0; Uptime = New-TimeSpan }
+            $vm2 = [PSCustomObject]@{ Id = $guid2; Name = "dup"; State = "Running"; CPUUsage = 10; MemoryAssigned = 1GB; Uptime = New-TimeSpan }
+            $vm1 | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+            $vm2 | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+            Mock Get-VM -MockWith { return @($vm1, $vm2) }
+
+            $result = Get-HvoVmByName -Name "dup"
+
+            $result.Count | Should -Be 2
+            $result[0].Id | Should -Be $guid1.ToString()
+            $result[1].Id | Should -Be $guid2.ToString()
+        }
+    }
+
     Describe "Set-HvoVm" {
         Context "When the VM does not exist" {
             It "Should return Updated = false with an error" {
-                # Arrange
-                $vmName = "non-existent-vm"
+                $vmId = [guid]'00000000-0000-0000-0000-000000000001'
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $null }
 
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+                $result = Set-HvoVm -Id $vmId.ToString() -MemoryMB 2048
 
-                # Act
-                $result = Set-HvoVm -Name $vmName -MemoryMB 2048
-
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $false
                 $result.Error | Should -Be "VM not found"
@@ -335,20 +385,13 @@ InModuleScope HvoVm {
 
         Context "When the VM is not stopped" {
             It "Should return Updated = false with an error" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Id = $vmId; Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
 
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                $result = Set-HvoVm -Id $vmId.ToString() -MemoryMB 2048
 
-                # Act
-                $result = Set-HvoVm -Name $vmName -MemoryMB 2048
-
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $false
                 $result.Error | Should -Be "VM must be Off to update"
@@ -358,76 +401,45 @@ InModuleScope HvoVm {
 
         Context "When the VM is stopped" {
             It "Should update memory if different" {
-                # Arrange
-                $vmName = "stopped-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                    MemoryStartup = 1GB
-                    ProcessorCount = 2
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Id = $vmId; Name = "stopped-vm"; State = "Off"; MemoryStartup = 1GB; ProcessorCount = 2 }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Get-VMNetworkAdapter -MockWith { return $null }
                 Mock Set-VMMemory -MockWith { }
 
-                # Act
-                $result = Set-HvoVm -Name $vmName -MemoryMB 2048
+                $result = Set-HvoVm -Id $vmId.ToString() -MemoryMB 2048
 
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $true
                 Should -Invoke Set-VMMemory -Exactly -Times 1 -ParameterFilter {
-                    $VMName -eq $vmName -and $StartupBytes -eq (2048 * 1MB)
+                    $VMName -eq "stopped-vm" -and $StartupBytes -eq (2048 * 1MB)
                 }
             }
 
             It "Should update the number of vCPUs if different" {
-                # Arrange
-                $vmName = "stopped-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                    MemoryStartup = 1GB
-                    ProcessorCount = 2
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Id = $vmId; Name = "stopped-vm"; State = "Off"; MemoryStartup = 1GB; ProcessorCount = 2 }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Get-VMNetworkAdapter -MockWith { return $null }
                 Mock Set-VMProcessor -MockWith { }
 
-                # Act
-                $result = Set-HvoVm -Name $vmName -Vcpu 4
+                $result = Set-HvoVm -Id $vmId.ToString() -Vcpu 4
 
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $true
                 Should -Invoke Set-VMProcessor -Exactly -Times 1 -ParameterFilter {
-                    $VMName -eq $vmName -and $Count -eq 4
+                    $VMName -eq "stopped-vm" -and $Count -eq 4
                 }
             }
 
             It "Should return Unchanged = true if no changes are needed" {
-                # Arrange
-                $vmName = "stopped-vm"
-                # Use exactly 1024MB to avoid precision issues
+                $vmId = $script:testVmGuid
                 $memoryBytes = 1024 * 1MB
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                    MemoryStartup = $memoryBytes
-                    ProcessorCount = 2
-                }
+                $mockVm = [PSCustomObject]@{ Id = $vmId; Name = "stopped-vm"; State = "Off"; MemoryStartup = $memoryBytes; ProcessorCount = 2 }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
+                $mockNic = [PSCustomObject]@{ SwitchName = "existing-switch" }
 
-                $mockNic = [PSCustomObject]@{
-                    SwitchName = "existing-switch"
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                # Get-VMNetworkAdapter can return a single object or an array
-                # The code uses $currentNic?.SwitchName which works on a single object
-                # For this test, we simulate a single object (not an array) so the code works
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Get-VMNetworkAdapter -MockWith { return $mockNic }
                 Mock Get-VMDvdDrive -MockWith { return $null }
                 Mock Set-VMMemory -MockWith { }
@@ -437,14 +449,11 @@ InModuleScope HvoVm {
                 Mock Remove-VMDvdDrive -MockWith { }
                 Mock Add-VMDvdDrive -MockWith { }
 
-                # Act
-                $result = Set-HvoVm -Name $vmName -MemoryMB 1024 -Vcpu 2 -SwitchName "existing-switch"
+                $result = Set-HvoVm -Id $vmId.ToString() -MemoryMB 1024 -Vcpu 2 -SwitchName "existing-switch"
 
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $false
                 $result.Unchanged | Should -Be $true
-                # Verify that no modifications were made
                 Should -Not -Invoke Set-VMMemory
                 Should -Not -Invoke Set-VMProcessor
                 Should -Not -Invoke Remove-VMNetworkAdapter
@@ -452,58 +461,35 @@ InModuleScope HvoVm {
             }
 
             It "Should update the switch if different" {
-                # Arrange
-                $vmName = "stopped-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                    MemoryStartup = 1GB
-                    ProcessorCount = 2
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Id = $vmId; Name = "stopped-vm"; State = "Off"; MemoryStartup = 1GB; ProcessorCount = 2 }
+                $mockNic = [PSCustomObject]@{ SwitchName = "old-switch" }
 
-                $mockNic = [PSCustomObject]@{
-                    SwitchName = "old-switch"
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Get-VMNetworkAdapter -MockWith { return $mockNic }
                 Mock Get-VMDvdDrive -MockWith { return $null }
                 Mock Remove-VMNetworkAdapter -MockWith { }
                 Mock Add-VMNetworkAdapter -MockWith { }
 
-                # Act
-                $result = Set-HvoVm -Name $vmName -SwitchName "new-switch"
+                $result = Set-HvoVm -Id $vmId.ToString() -SwitchName "new-switch"
 
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $true
-                Should -Invoke Remove-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter {
-                    $VMName -eq $vmName
-                }
-                Should -Invoke Add-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter {
-                    $VMName -eq $vmName -and $SwitchName -eq "new-switch"
-                }
+                # Remove-VMNetworkAdapter is called via pipeline, so no -VMName bound
+                Should -Invoke Remove-VMNetworkAdapter -Exactly -Times 1
+                Should -Invoke Add-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter { $VMName -eq "stopped-vm" -and $SwitchName -eq "new-switch" }
             }
 
             It "Should return an error if ISO file does not exist" {
-                # Arrange
-                $vmName = "stopped-vm"
+                $vmId = $script:testVmGuid
                 $isoPath = "/tmp/ISOs/nonexistent.iso"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                    MemoryStartup = 1GB
-                    ProcessorCount = 2
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                $mockVm = [PSCustomObject]@{ Id = $vmId; Name = "stopped-vm"; State = "Off"; MemoryStartup = 1GB; ProcessorCount = 2 }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Get-VMNetworkAdapter -MockWith { return $null }
                 Mock Test-Path -ParameterFilter { $Path -eq $isoPath } -MockWith { return $false }
 
-                # Act
-                $result = Set-HvoVm -Name $vmName -IsoPath $isoPath
+                $result = Set-HvoVm -Id $vmId.ToString() -IsoPath $isoPath
 
-                # Assert
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $false
                 $result.Error | Should -Be "ISO file not found"
@@ -515,36 +501,21 @@ InModuleScope HvoVm {
     Describe "Start-HvoVm" {
         Context "When the VM does not exist" {
             It "Should return null" {
-                # Arrange
-                $vmName = "non-existent-vm"
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
-
-                # Act
-                $result = Start-HvoVm -Name $vmName
-
-                # Assert
+                $vmId = [guid]'00000000-0000-0000-0000-000000000001'
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $null }
+                $result = Start-HvoVm -Id $vmId.ToString()
                 $result | Should -BeNullOrEmpty
             }
         }
 
         Context "When the VM is already running" {
             It "Should return AlreadyRunning = true" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Start-VM -MockWith { }
-
-                # Act
-                $result = Start-HvoVm -Name $vmName
-
-                # Assert
+                $result = Start-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Started | Should -Be $false
                 $result.AlreadyRunning | Should -Be $true
@@ -554,108 +525,65 @@ InModuleScope HvoVm {
 
         Context "When the VM is stopped" {
             It "Should start the VM" {
-                # Arrange
-                $vmName = "stopped-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "stopped-vm"; State = "Off" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Start-VM -MockWith { }
-
-                # Act
-                $result = Start-HvoVm -Name $vmName
-
-                # Assert
+                $result = Start-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Started | Should -Be $true
-                $result.AlreadyRunning | Should -Be $false
-                Should -Invoke Start-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+                Should -Invoke Start-VM -Exactly -Times 1 -ParameterFilter { $Name -eq "stopped-vm" }
             }
         }
 
         Context "When the VM is paused" {
             It "Should resume the VM" {
-                # Arrange
-                $vmName = "paused-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Paused"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "paused-vm"; State = "Paused" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Resume-VM -MockWith { }
-
-                # Act
-                $result = Start-HvoVm -Name $vmName
-
-                # Assert
+                $result = Start-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Started | Should -Be $true
                 $result.Resumed | Should -Be $true
-                Should -Invoke Resume-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+                Should -Invoke Resume-VM -Exactly -Times 1 -ParameterFilter { $Name -eq "paused-vm" }
             }
         }
 
         Context "When the VM is saved" {
             It "Should start the VM from saved state" {
-                # Arrange
-                $vmName = "saved-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Saved"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "saved-vm"; State = "Saved" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Start-VM -MockWith { }
-
-                # Act
-                $result = Start-HvoVm -Name $vmName
-
-                # Assert
+                $result = Start-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Started | Should -Be $true
-                $result.Resumed | Should -Be $false
-                Should -Invoke Start-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+                Should -Invoke Start-VM -Exactly -Times 1 -ParameterFilter { $Name -eq "saved-vm" }
             }
         }
 
         Context "When the VM is in an invalid state" {
             It "Should throw an exception for invalid state" {
-                # Arrange
-                $vmName = "invalid-state-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Starting"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "invalid-vm"; State = "Starting" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-
-                # Act & Assert
-                { Start-HvoVm -Name $vmName } | Should -Throw "*invalid state for starting*"
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                { Start-HvoVm -Id $vmId.ToString() } | Should -Throw "*invalid state for starting*"
             }
         }
 
         Context "When an exception occurs" {
             It "Should propagate exceptions that are not 'not found' errors" {
-                # Arrange
-                $vmName = "vm-with-error"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "vm-with-error"; State = "Off" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Start-VM -MockWith { throw "Access denied" }
-
-                # Act & Assert
-                { Start-HvoVm -Name $vmName } | Should -Throw "Access denied"
+                { Start-HvoVm -Id $vmId.ToString() } | Should -Throw "Access denied"
             }
         }
     }
@@ -663,36 +591,21 @@ InModuleScope HvoVm {
     Describe "Stop-HvoVm" {
         Context "When the VM does not exist" {
             It "Should return null" {
-                # Arrange
-                $vmName = "non-existent-vm"
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
-
-                # Act
-                $result = Stop-HvoVm -Name $vmName
-
-                # Assert
+                $vmId = [guid]'00000000-0000-0000-0000-000000000001'
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $null }
+                $result = Stop-HvoVm -Id $vmId.ToString()
                 $result | Should -BeNullOrEmpty
             }
         }
 
         Context "When the VM is already stopped" {
             It "Should return AlreadyStopped = true" {
-                # Arrange
-                $vmName = "stopped-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "stopped-vm"; State = "Off" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Stop-VM -MockWith { }
-
-                # Act
-                $result = Stop-HvoVm -Name $vmName
-
-                # Assert
+                $result = Stop-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Stopped | Should -Be $false
                 $result.AlreadyStopped | Should -Be $true
@@ -702,96 +615,52 @@ InModuleScope HvoVm {
 
         Context "When the VM is running" {
             It "Should stop the VM with force if the Force parameter is used" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Stop-VM -MockWith { }
-
-                # Act
-                $result = Stop-HvoVm -Name $vmName -Force
-
-                # Assert
+                $result = Stop-HvoVm -Id $vmId.ToString() -Force
                 $result | Should -Not -BeNullOrEmpty
                 $result.Stopped | Should -Be $true
                 Should -Invoke Stop-VM -Exactly -Times 1
             }
 
             It "Should stop the VM gracefully when shutdown service is available and enabled" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                $mockShutdownService = [PSCustomObject]@{
-                    Name = "Shutdown"
-                    Enabled = $true
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
+                $mockShutdownService = [PSCustomObject]@{ Name = "Shutdown"; Enabled = $true }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq "running-vm" -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
                 Mock Stop-VM -MockWith { }
-
-                # Act
-                $result = Stop-HvoVm -Name $vmName
-
-                # Assert
+                $result = Stop-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Stopped | Should -Be $true
-                Should -Invoke Get-VMIntegrationService -Exactly -Times 1 -ParameterFilter {
-                    $VMName -eq $vmName -and $Name -eq "Shutdown"
-                }
-                Should -Invoke Stop-VM -Exactly -Times 1 -ParameterFilter {
-                    $Name -eq $vmName -and -not $PSBoundParameters.ContainsKey('Force')
-                }
+                Should -Invoke Get-VMIntegrationService -Exactly -Times 1 -ParameterFilter { $VMName -eq "running-vm" -and $Name -eq "Shutdown" }
+                Should -Invoke Stop-VM -Exactly -Times 1 -ParameterFilter { $Name -eq "running-vm" -and -not $PSBoundParameters.ContainsKey('Force') }
             }
 
             It "Should throw an exception when shutdown service is not available" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $null }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq "running-vm" -and $Name -eq "Shutdown" } -MockWith { return $null }
                 Mock Stop-VM -MockWith { }
-
-                # Act & Assert
-                { Stop-HvoVm -Name $vmName } | Should -Throw "*SHUTDOWN_SERVICE_NOT_AVAILABLE*"
+                { Stop-HvoVm -Id $vmId.ToString() } | Should -Throw "*SHUTDOWN_SERVICE_NOT_AVAILABLE*"
                 Should -Not -Invoke Stop-VM
             }
 
             It "Should throw an exception when shutdown service is not enabled" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                $mockShutdownService = [PSCustomObject]@{
-                    Name = "Shutdown"
-                    Enabled = $false
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
+                $mockShutdownService = [PSCustomObject]@{ Name = "Shutdown"; Enabled = $false }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq "running-vm" -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
                 Mock Stop-VM -MockWith { }
-
-                # Act & Assert
-                { Stop-HvoVm -Name $vmName } | Should -Throw "*SHUTDOWN_SERVICE_NOT_ENABLED*"
+                { Stop-HvoVm -Id $vmId.ToString() } | Should -Throw "*SHUTDOWN_SERVICE_NOT_ENABLED*"
                 Should -Not -Invoke Stop-VM
             }
         }
@@ -800,134 +669,75 @@ InModuleScope HvoVm {
     Describe "Restart-HvoVm" {
         Context "When the VM does not exist" {
             It "Should return null" {
-                # Arrange
-                $vmName = "non-existent-vm"
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
-
-                # Act
-                $result = Restart-HvoVm -Name $vmName
-
-                # Assert
+                $vmId = [guid]'00000000-0000-0000-0000-000000000001'
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $null }
+                $result = Restart-HvoVm -Id $vmId.ToString()
                 $result | Should -BeNullOrEmpty
             }
         }
 
         Context "When the VM is stopped" {
             It "Should start the VM (idempotence)" {
-                # Arrange
-                $vmName = "stopped-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "stopped-vm"; State = "Off" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Start-VM -MockWith { }
-
-                # Act
-                $result = Restart-HvoVm -Name $vmName
-
-                # Assert
+                $result = Restart-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Restarted | Should -Be $true
-                Should -Invoke Start-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+                Should -Invoke Start-VM -Exactly -Times 1 -ParameterFilter { $Name -eq "stopped-vm" }
             }
         }
 
         Context "When the VM is running" {
             It "Should restart the VM with force if the Force parameter is used" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Restart-VM -MockWith { }
-
-                # Act
-                $result = Restart-HvoVm -Name $vmName -Force
-
-                # Assert
+                $result = Restart-HvoVm -Id $vmId.ToString() -Force
                 $result | Should -Not -BeNullOrEmpty
                 $result.Restarted | Should -Be $true
                 Should -Invoke Restart-VM -Exactly -Times 1
             }
 
             It "Should restart the VM gracefully when shutdown service is available and enabled" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                $mockShutdownService = [PSCustomObject]@{
-                    Name = "Shutdown"
-                    Enabled = $true
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
+                $mockShutdownService = [PSCustomObject]@{ Name = "Shutdown"; Enabled = $true }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq "running-vm" -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
                 Mock Restart-VM -MockWith { }
-
-                # Act
-                $result = Restart-HvoVm -Name $vmName
-
-                # Assert
+                $result = Restart-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Restarted | Should -Be $true
-                Should -Invoke Get-VMIntegrationService -Exactly -Times 1 -ParameterFilter {
-                    $VMName -eq $vmName -and $Name -eq "Shutdown"
-                }
-                Should -Invoke Restart-VM -Exactly -Times 1 -ParameterFilter {
-                    $Name -eq $vmName -and -not $PSBoundParameters.ContainsKey('Force')
-                }
+                Should -Invoke Get-VMIntegrationService -Exactly -Times 1 -ParameterFilter { $VMName -eq "running-vm" -and $Name -eq "Shutdown" }
+                Should -Invoke Restart-VM -Exactly -Times 1 -ParameterFilter { $Name -eq "running-vm" -and -not $PSBoundParameters.ContainsKey('Force') }
             }
 
             It "Should throw an exception when shutdown service is not available" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $null }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq "running-vm" -and $Name -eq "Shutdown" } -MockWith { return $null }
                 Mock Restart-VM -MockWith { }
-
-                # Act & Assert
-                { Restart-HvoVm -Name $vmName } | Should -Throw "*SHUTDOWN_SERVICE_NOT_AVAILABLE*"
+                { Restart-HvoVm -Id $vmId.ToString() } | Should -Throw "*SHUTDOWN_SERVICE_NOT_AVAILABLE*"
                 Should -Not -Invoke Restart-VM
             }
 
             It "Should throw an exception when shutdown service is not enabled" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                $mockShutdownService = [PSCustomObject]@{
-                    Name = "Shutdown"
-                    Enabled = $false
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq $vmName -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
+                $mockShutdownService = [PSCustomObject]@{ Name = "Shutdown"; Enabled = $false }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMIntegrationService -ParameterFilter { $VMName -eq "running-vm" -and $Name -eq "Shutdown" } -MockWith { return $mockShutdownService }
                 Mock Restart-VM -MockWith { }
-
-                # Act & Assert
-                { Restart-HvoVm -Name $vmName } | Should -Throw "*SHUTDOWN_SERVICE_NOT_ENABLED*"
+                { Restart-HvoVm -Id $vmId.ToString() } | Should -Throw "*SHUTDOWN_SERVICE_NOT_ENABLED*"
                 Should -Not -Invoke Restart-VM
             }
         }
@@ -936,36 +746,21 @@ InModuleScope HvoVm {
     Describe "Suspend-HvoVm" {
         Context "When the VM does not exist" {
             It "Should return null" {
-                # Arrange
-                $vmName = "non-existent-vm"
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
-
-                # Act
-                $result = Suspend-HvoVm -Name $vmName
-
-                # Assert
+                $vmId = [guid]'00000000-0000-0000-0000-000000000001'
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $null }
+                $result = Suspend-HvoVm -Id $vmId.ToString()
                 $result | Should -BeNullOrEmpty
             }
         }
 
         Context "When the VM is already paused" {
             It "Should return AlreadySuspended = true" {
-                # Arrange
-                $vmName = "paused-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Paused"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "paused-vm"; State = "Paused" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Suspend-VM -MockWith { }
-
-                # Act
-                $result = Suspend-HvoVm -Name $vmName
-
-                # Assert
+                $result = Suspend-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Suspended | Should -Be $false
                 $result.AlreadySuspended | Should -Be $true
@@ -975,60 +770,36 @@ InModuleScope HvoVm {
 
         Context "When the VM is running" {
             It "Should suspend the VM" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Suspend-VM -MockWith { }
-
-                # Act
-                $result = Suspend-HvoVm -Name $vmName
-
-                # Assert
+                $result = Suspend-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Suspended | Should -Be $true
-                $result.AlreadySuspended | Should -Be $false
-                Should -Invoke Suspend-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+                Should -Invoke Suspend-VM -Exactly -Times 1 -ParameterFilter { $Name -eq "running-vm" }
             }
         }
 
         Context "When the VM is in an invalid state" {
             It "Should throw an exception for invalid state" {
-                # Arrange
-                $vmName = "invalid-state-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "invalid-vm"; State = "Off" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-
-                # Act & Assert
-                { Suspend-HvoVm -Name $vmName } | Should -Throw "*invalid state for suspending*"
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                { Suspend-HvoVm -Id $vmId.ToString() } | Should -Throw "*invalid state for suspending*"
             }
         }
 
         Context "When an exception occurs" {
             It "Should propagate exceptions that are not 'not found' errors" {
-                # Arrange
-                $vmName = "vm-with-error"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "vm-with-error"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Suspend-VM -MockWith { throw "Access denied" }
-
-                # Act & Assert
-                { Suspend-HvoVm -Name $vmName } | Should -Throw "Access denied"
+                { Suspend-HvoVm -Id $vmId.ToString() } | Should -Throw "Access denied"
             }
         }
     }
@@ -1036,36 +807,21 @@ InModuleScope HvoVm {
     Describe "Resume-HvoVm" {
         Context "When the VM does not exist" {
             It "Should return null" {
-                # Arrange
-                $vmName = "non-existent-vm"
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
-
-                # Act
-                $result = Resume-HvoVm -Name $vmName
-
-                # Assert
+                $vmId = [guid]'00000000-0000-0000-0000-000000000001'
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $null }
+                $result = Resume-HvoVm -Id $vmId.ToString()
                 $result | Should -BeNullOrEmpty
             }
         }
 
         Context "When the VM is already running" {
             It "Should return AlreadyRunning = true" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Resume-VM -MockWith { }
-
-                # Act
-                $result = Resume-HvoVm -Name $vmName
-
-                # Assert
+                $result = Resume-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Resumed | Should -Be $false
                 $result.AlreadyRunning | Should -Be $true
@@ -1075,42 +831,25 @@ InModuleScope HvoVm {
 
         Context "When the VM is paused" {
             It "Should resume the VM" {
-                # Arrange
-                $vmName = "paused-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Paused"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "paused-vm"; State = "Paused" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Resume-VM -MockWith { }
-
-                # Act
-                $result = Resume-HvoVm -Name $vmName
-
-                # Assert
+                $result = Resume-HvoVm -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Resumed | Should -Be $true
-                $result.AlreadyRunning | Should -Be $false
-                Should -Invoke Resume-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+                Should -Invoke Resume-VM -Exactly -Times 1 -ParameterFilter { $Name -eq "paused-vm" }
             }
         }
 
         Context "When the VM is stopped" {
             It "Should throw an exception" {
-                # Arrange
-                $vmName = "stopped-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "stopped-vm"; State = "Off" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-
-                # Act & Assert
-                { Resume-HvoVm -Name $vmName } | Should -Throw
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                { Resume-HvoVm -Id $vmId.ToString() } | Should -Throw
             }
         }
     }
@@ -1118,16 +857,10 @@ InModuleScope HvoVm {
     Describe "Remove-HvoVm" {
         Context "When the VM does not exist" {
             It "Should return false" {
-                # Arrange
-                $vmName = "non-existent-vm"
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+                $vmId = [guid]'00000000-0000-0000-0000-000000000001'
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $null }
                 Mock Remove-VM -MockWith { }
-
-                # Act
-                $result = Remove-HvoVm -Name $vmName
-
-                # Assert
+                $result = Remove-HvoVm -Id $vmId.ToString()
                 $result | Should -Be $false
                 Should -Not -Invoke Remove-VM
             }
@@ -1135,140 +868,83 @@ InModuleScope HvoVm {
 
         Context "When the VM exists" {
             It "Should stop the VM if it is running before deletion" {
-                # Arrange
-                $vmName = "running-vm"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Running"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "running-vm"; State = "Running" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Stop-VM -MockWith { }
                 Mock Get-VMSnapshot -MockWith { return $null }
                 Mock Get-VMDvdDrive -MockWith { return @() }
                 Mock Get-VMHardDiskDrive -MockWith { return @() }
                 Mock Remove-VM -MockWith { }
-
-                # Act
-                $result = Remove-HvoVm -Name $vmName
-
-                # Assert
+                $result = Remove-HvoVm -Id $vmId.ToString()
                 $result | Should -Be $true
                 Should -Invoke Stop-VM -Exactly -Times 1
                 Should -Invoke Remove-VM -Exactly -Times 1
             }
 
             It "Should remove snapshots before deletion" {
-                # Arrange
-                $vmName = "vm-with-snapshots"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "vm-with-snapshots"; State = "Off" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-                $mockSnapshots = @(
-                    [PSCustomObject]@{ Name = "snapshot1" },
-                    [PSCustomObject]@{ Name = "snapshot2" }
-                )
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                $mockSnapshots = @([PSCustomObject]@{ Name = "snapshot1" }, [PSCustomObject]@{ Name = "snapshot2" })
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Get-VMSnapshot -MockWith { return $mockSnapshots }
                 Mock Remove-VMSnapshot -MockWith { }
                 Mock Get-VMDvdDrive -MockWith { return @() }
                 Mock Get-VMHardDiskDrive -MockWith { return @() }
                 Mock Remove-VM -MockWith { }
-
-                # Act
-                $result = Remove-HvoVm -Name $vmName
-
-                # Assert
+                $result = Remove-HvoVm -Id $vmId.ToString()
                 $result | Should -Be $true
-                Should -Invoke Remove-VMSnapshot -Exactly -Times 1 -ParameterFilter {
-                    $VMName -eq $vmName
-                }
+                Should -Invoke Remove-VMSnapshot -Exactly -Times 1 -ParameterFilter { $VMName -eq "vm-with-snapshots" }
             }
 
             It "Should remove disks if RemoveDisks is true" {
-                # Arrange
-                $vmName = "vm-with-disks"
+                $vmId = $script:testVmGuid
                 $diskPath = "/tmp/VMs/vm-with-disks.vhdx"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                }
+                $mockVm = [PSCustomObject]@{ Name = "vm-with-disks"; State = "Off" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-                $mockDisk = [PSCustomObject]@{
-                    Path = $diskPath
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                $mockDisk = [PSCustomObject]@{ Path = $diskPath }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Get-VMSnapshot -MockWith { return $null }
                 Mock Get-VMDvdDrive -MockWith { return @() }
                 Mock Get-VMHardDiskDrive -MockWith { return @($mockDisk) }
                 Mock Test-Path -ParameterFilter { $Path -eq $diskPath } -MockWith { return $true }
                 Mock Remove-Item -MockWith { }
                 Mock Remove-VM -MockWith { }
-
-                # Act
-                $result = Remove-HvoVm -Name $vmName -RemoveDisks $true
-
-                # Assert
+                $result = Remove-HvoVm -Id $vmId.ToString() -RemoveDisks $true
                 $result | Should -Be $true
-                Should -Invoke Remove-Item -Exactly -Times 1 -ParameterFilter {
-                    $Path -eq $diskPath -and $Force -eq $true
-                }
+                Should -Invoke Remove-Item -Exactly -Times 1 -ParameterFilter { $Path -eq $diskPath -and $Force -eq $true }
             }
 
             It "Should remove DVD drives before deletion" {
-                # Arrange
-                $vmName = "vm-with-dvd"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "vm-with-dvd"; State = "Off" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-                $mockDvdDrive = [PSCustomObject]@{
-                    ControllerNumber = 0
-                    ControllerLocation = 0
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                $mockDvdDrive = [PSCustomObject]@{ ControllerNumber = 0; ControllerLocation = 0 }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Get-VMSnapshot -MockWith { return $null }
                 Mock Get-VMDvdDrive -MockWith { return @($mockDvdDrive) }
                 Mock Remove-VMDvdDrive -MockWith { }
                 Mock Get-VMHardDiskDrive -MockWith { return @() }
                 Mock Remove-VM -MockWith { }
-
-                # Act
-                $result = Remove-HvoVm -Name $vmName
-
-                # Assert
+                $result = Remove-HvoVm -Id $vmId.ToString()
                 $result | Should -Be $true
                 Should -Invoke Remove-VMDvdDrive -Exactly -Times 1 -ParameterFilter {
-                    $VMName -eq $vmName -and
-                    $ControllerNumber -eq 0 -and
-                    $ControllerLocation -eq 0
+                    $VMName -eq "vm-with-dvd" -and $ControllerNumber -eq 0 -and $ControllerLocation -eq 0
                 }
             }
 
             It "Should handle exceptions that are not 'not found' errors" {
-                # Arrange
-                $vmName = "vm-with-error"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                    State = "Off"
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "vm-with-error"; State = "Off" }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
                 Mock Get-VMSnapshot -MockWith { return $null }
                 Mock Get-VMDvdDrive -MockWith { return @() }
                 Mock Get-VMHardDiskDrive -MockWith { return @() }
                 Mock Remove-VM -MockWith { throw "Access denied" }
-
-                # Act & Assert
-                { Remove-HvoVm -Name $vmName } | Should -Throw "Access denied"
+                { Remove-HvoVm -Id $vmId.ToString() } | Should -Throw "Access denied"
             }
         }
     }
@@ -1276,128 +952,81 @@ InModuleScope HvoVm {
     Describe "Get-HvoVmNetworkAdapters" {
         Context "When the VM does not exist" {
             It "Should return null" {
-                # Arrange
-                $vmName = "non-existent-vm"
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $null }
+                $vmId = [guid]'00000000-0000-0000-0000-000000000001'
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $null }
                 Mock Get-VMNetworkAdapter -MockWith { }
-
-                # Act
-                $result = Get-HvoVmNetworkAdapters -Name $vmName
-
-                # Assert
+                $result = Get-HvoVmNetworkAdapters -Id $vmId.ToString()
                 $result | Should -BeNullOrEmpty
-                Should -Invoke Get-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
+                Should -Invoke Get-VM -Exactly -Times 1 -ParameterFilter { $Id -eq $vmId }
                 Should -Invoke Get-VMNetworkAdapter -Exactly -Times 0
             }
         }
 
         Context "When the VM exists with network adapters" {
-            It "Should return a formatted list of adapters" {
-                # Arrange
-                $vmName = "vm-with-adapters"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                }
-
-                # Create mock status object with ToString method
+            It "Should return a formatted list of adapters with Id" {
+                $vmId = $script:testVmGuid
+                $adapterId1 = [guid]::NewGuid()
+                $adapterId2 = [guid]::NewGuid()
+                $mockVm = [PSCustomObject]@{ Name = "vm-with-adapters" }
                 $mockStatus1 = [PSCustomObject]@{ Value = "Ok" }
                 $mockStatus1 | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return "Ok" } -Force
-
                 $mockAdapter1 = [PSCustomObject]@{
-                    Name       = "Network Adapter"
-                    SwitchName = "LAN"
-                    IsLegacy   = $false
-                    MacAddress = "00155D012345"
-                    Status     = $mockStatus1
+                    Id = $adapterId1; Name = "Network Adapter"; SwitchName = "LAN"; IsLegacy = $false
+                    MacAddress = "00155D012345"; Status = $mockStatus1
                 }
-
                 $mockStatus2 = [PSCustomObject]@{ Value = "Ok" }
                 $mockStatus2 | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return "Ok" } -Force
-
                 $mockAdapter2 = [PSCustomObject]@{
-                    Name       = "Legacy Network Adapter"
-                    SwitchName = "WAN"
-                    IsLegacy   = $true
-                    MacAddress = "00155D012346"
-                    Status     = $mockStatus2
+                    Id = $adapterId2; Name = "Legacy Network Adapter"; SwitchName = "WAN"; IsLegacy = $true
+                    MacAddress = "00155D012346"; Status = $mockStatus2
                 }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -ParameterFilter { $VMName -eq $vmName } -MockWith { return @($mockAdapter1, $mockAdapter2) }
-
-                # Act
-                $result = Get-HvoVmNetworkAdapters -Name $vmName
-
-                # Assert
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return @($mockAdapter1, $mockAdapter2) }
+                $result = Get-HvoVmNetworkAdapters -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Count | Should -Be 2
+                $result[0].Id | Should -Be $adapterId1.ToString()
                 $result[0].Name | Should -Be "Network Adapter"
                 $result[0].SwitchName | Should -Be "LAN"
                 $result[0].Type | Should -Be "Synthetic"
-                $result[0].MacAddress | Should -Be "00155D012345"
-                $result[0].Status | Should -Be "Ok"
+                $result[1].Id | Should -Be $adapterId2.ToString()
                 $result[1].Name | Should -Be "Legacy Network Adapter"
                 $result[1].Type | Should -Be "Legacy"
-                Should -Invoke Get-VM -Exactly -Times 1 -ParameterFilter { $Name -eq $vmName }
-                Should -Invoke Get-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter { $VMName -eq $vmName }
+                Should -Invoke Get-VM -Exactly -Times 1 -ParameterFilter { $Id -eq $vmId }
+                Should -Invoke Get-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter { $null -ne $VM }
             }
 
             It "Should handle a single adapter (not an array)" {
-                # Arrange
-                $vmName = "vm-with-single-adapter"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                }
-
+                $vmId = $script:testVmGuid
+                $adapterId = [guid]::NewGuid()
+                $mockVm = [PSCustomObject]@{ Name = "vm-with-single-adapter" }
                 $mockStatus = [PSCustomObject]@{ Value = "Ok" }
                 $mockStatus | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return "Ok" } -Force
-
                 $mockAdapter = [PSCustomObject]@{
-                    Name       = "Network Adapter"
-                    SwitchName = "LAN"
-                    IsLegacy   = $false
-                    MacAddress = "00155D012345"
-                    Status     = $mockStatus
+                    Id = $adapterId; Name = "Network Adapter"; SwitchName = "LAN"; IsLegacy = $false
+                    MacAddress = "00155D012345"; Status = $mockStatus
                 }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -ParameterFilter { $VMName -eq $vmName } -MockWith { return $mockAdapter }
-
-                # Act
-                $result = Get-HvoVmNetworkAdapters -Name $vmName
-
-                # Assert
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return $mockAdapter }
+                $result = Get-HvoVmNetworkAdapters -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Count | Should -Be 1
+                $result[0].Id | Should -Be $adapterId.ToString()
                 $result[0].Name | Should -Be "Network Adapter"
             }
 
             It "Should handle adapter without switch (SwitchName is null)" {
-                # Arrange
-                $vmName = "vm-with-unconnected-adapter"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                }
-
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "vm-with-unconnected-adapter" }
                 $mockStatus = [PSCustomObject]@{ Value = "Ok" }
                 $mockStatus | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return "Ok" } -Force
-
                 $mockAdapter = [PSCustomObject]@{
-                    Name       = "Network Adapter"
-                    SwitchName = $null
-                    IsLegacy   = $false
-                    MacAddress = "00155D012345"
-                    Status     = $mockStatus
+                    InstanceId = [guid]::NewGuid(); Name = "Network Adapter"; SwitchName = $null; IsLegacy = $false
+                    MacAddress = "00155D012345"; Status = $mockStatus
                 }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -ParameterFilter { $VMName -eq $vmName } -MockWith { return $mockAdapter }
-
-                # Act
-                $result = Get-HvoVmNetworkAdapters -Name $vmName
-
-                # Assert
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return $mockAdapter }
+                $result = Get-HvoVmNetworkAdapters -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result[0].SwitchName | Should -BeNullOrEmpty
             }
@@ -1405,24 +1034,12 @@ InModuleScope HvoVm {
 
         Context "When the VM exists without network adapters" {
             It "Should return an empty array" {
-                # Arrange
-                $vmName = "vm-without-adapters"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -MockWith { return $null }
-
-                # Act
-                $result = Get-HvoVmNetworkAdapters -Name $vmName
-
-                # Assert
-                # The function returns @() which may be converted to $null by PowerShell pipeline
-                # We check that the result is either $null or an empty array
-                if ($null -ne $result) {
-                    $result.Count | Should -Be 0
-                }
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "vm-without-adapters" }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return $null }
+                $result = Get-HvoVmNetworkAdapters -Id $vmId.ToString()
+                if ($null -ne $result) { $result.Count | Should -Be 0 }
                 Should -Invoke Get-VM -Exactly -Times 1
                 Should -Invoke Get-VMNetworkAdapter -Exactly -Times 1
             }
@@ -1430,35 +1047,54 @@ InModuleScope HvoVm {
 
         Context "When Get-VMNetworkAdapter throws an error" {
             It "Should propagate the error if it's not a 'not found' error" {
-                # Arrange
-                $vmName = "vm-with-error"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -ParameterFilter { $VMName -eq $vmName } -MockWith { throw "Access denied" }
-
-                # Act & Assert
-                { Get-HvoVmNetworkAdapters -Name $vmName } | Should -Throw "Access denied"
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "vm-with-error" }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { throw "Access denied" }
+                { Get-HvoVmNetworkAdapters -Id $vmId.ToString() } | Should -Throw "Access denied"
             }
 
             It "Should return null if the error matches 'not found'" {
-                # Arrange
-                $vmName = "vm-with-not-found-error"
-                $mockVm = [PSCustomObject]@{
-                    Name = $vmName
-                }
-
-                Mock Get-VM -ParameterFilter { $Name -eq $vmName } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -ParameterFilter { $VMName -eq $vmName } -MockWith { throw "VM not found" }
-
-                # Act
-                $result = Get-HvoVmNetworkAdapters -Name $vmName
-
-                # Assert
+                $vmId = $script:testVmGuid
+                $mockVm = [PSCustomObject]@{ Name = "vm-with-not-found-error" }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { throw "VM not found" }
+                $result = Get-HvoVmNetworkAdapters -Id $vmId.ToString()
                 $result | Should -BeNullOrEmpty
             }
+        }
+    }
+
+    Describe "Remove-HvoVmNetworkAdapter" {
+        It "Should return false when VM does not exist" {
+            $vmId = [guid]'00000000-0000-0000-0000-000000000001'
+            $adapterId = [guid]::NewGuid().ToString()
+            Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $null }
+            $result = Remove-HvoVmNetworkAdapter -VMId $vmId.ToString() -AdapterId $adapterId
+            $result | Should -Be $false
+        }
+
+        It "Should return false when adapter is not found" {
+            $vmId = $script:testVmGuid
+            $mockVm = [PSCustomObject]@{ Name = "vm1" }
+            $mockAdapter = [PSCustomObject]@{ Id = [guid]::NewGuid(); Name = "NIC1" }
+            Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+            Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return $mockAdapter }
+            $result = Remove-HvoVmNetworkAdapter -VMId $vmId.ToString() -AdapterId "00000000-0000-0000-0000-000000000000"
+            $result | Should -Be $false
+        }
+
+        It "Should remove the adapter when VM and adapter exist" {
+            $vmId = $script:testVmGuid
+            $adapterId = [guid]::NewGuid()
+            $mockVm = [PSCustomObject]@{ Name = "vm1" }
+            $mockAdapter = [PSCustomObject]@{ Id = $adapterId; Name = "NIC1" }
+            Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+            Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return $mockAdapter }
+            Mock Remove-VMNetworkAdapter -MockWith { }
+            $result = Remove-HvoVmNetworkAdapter -VMId $vmId.ToString() -AdapterId $adapterId.ToString()
+            $result | Should -Be $true
+            Should -Invoke Remove-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter { $null -ne $VMNetworkAdapter }
         }
     }
 }


### PR DESCRIPTION
## Description

The API now identifies resources (VMs, switches) by **Id (GUID)**: routes use the `:id` path parameter, and name-based discovery uses `/vms/by-name/:name` and `/switches/by-name/:name`. 
An **API scenario test script** (`tests/run-api-tests.ps1`) runs the full API flow (health, OpenAPI, switches CRUD, VM lifecycle) and generates a report with Hyper-V cleanup instructions on failure. The DoD is updated with an "API Scenario Tests" section.

---

## Type of change

- [x] Feature (new functionality)
- [ ] Fix (bug fix)
- [ ] Refactor (no functional change)
- [x] Documentation update
- [ ] Chore / maintenance

---

## Context

- **Id-based identification**: VM/switch names are not unique; targeting by name in paths (`/vms/:name`, etc.) was ambiguous. The API now uses the Id (GUID) returned on creation for all operations (GET, PUT, DELETE, start, stop, etc.). Discovery by name remains via `GET /vms/by-name/:name` and `GET /switches/by-name/:name`.
- **Scenario tests**: To validate the full API without manual steps, a script runs HTTP calls against a running server, creates test resources (`hvo-test-{type}-<YYYYMMDDHHmm>`), removes them at the end, and produces a report. The DoD is updated to reference this test type for route or API behaviour changes.

---

## Changes

**Commit ff83f31 – Id (GUID) identification**

- All list and detail responses include `Id`; operations use `:id` in the path.
- **New endpoints**: `GET /vms/by-name/:name`, `GET /switches/by-name/:name` for discovery by name.
- `POST /vms` and `POST /switches` always create a resource and return **201** with `id`.
- **Removed** routes using `:name` (GET/PUT/DELETE `/vms/:name`, etc.); use `:id` everywhere.
- Network adapters: responses include `Id`; delete via `DELETE /vms/:id/network-adapters/:adapterId`.
- OpenAPI, `docs/api-reference.md`, CHANGELOG, and code (versioned docs/comments) updated; HvoVm/HvoSwitch modules and vms/switches routes refactored; unit tests updated.

**Commit 1243924 – API test script and documentation**

- **tests/run-api-tests.ps1**: Confirms server is running, calls `GET /health`, then Phase 1 (health, OpenAPI), Phase 2 (switches CRUD), Phase 3 (VM scenario: create, get, start, stop, network-adapters, update, delete). Report written to `tests/reports/api-test-report-<timestamp>.txt` with a "Remise en condition initiale Hyper-V" section on failure.
- **tests/reports/.gitkeep**: Report output directory.
- **tests/README.md**: "Tests API (scénario complet)" section (prerequisites, command, phases, report).
- **docs/dod/README.md**: "API Scenario Tests" section (prerequisites, execution, report/failures, when to run) and checklist item.

---

## Tests

- [x] Manual tests performed
- [x] Existing functionality verified
- [x] Documentation verified

Unit tests (Pester) run and updated for Id-based model. `run-api-tests.ps1` run manually with server up; report generated. README, DoD, CHANGELOG, and api-reference reviewed.

---

## Breaking changes

- [x] This PR introduces breaking changes

**BREAKING CHANGE** (commit ff83f31): The `:name` path parameter is removed from VM and switch routes.

- **Before**: `GET /vms/:name`, `PUT /vms/:name`, `DELETE /vms/:name` (same for `/switches/:name`).
- **After**: Use the **Id** (GUID) returned on creation in paths: `GET /vms/:id`, `PUT /vms/:id`, `DELETE /vms/:id`. To find a resource by name: `GET /vms/by-name/:name` or `GET /switches/by-name/:name`, then use the `Id` for subsequent calls.

See `CHANGELOG.md` and `docs/api-reference.md` for details.

---

## Checklist

- [x] Code follows project standards
- [x] Code comments added where necessary
- [x] Documentation updated (README and/or docs)
- [x] No secrets or sensitive information committed
- [x] No new external dependencies introduced