### PR TITLE
fix(api): modèle déclaratif adaptateurs réseau (issue #25)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -268,11 +268,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -320,11 +320,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "requestBody": {
@@ -426,11 +426,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -488,11 +488,11 @@
         "parameters": [
           {
             "name": "name",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -563,11 +563,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -643,11 +643,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "requestBody": {
@@ -727,11 +727,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -805,11 +805,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -867,18 +867,18 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           },
           {
             "name": "force",
+            "in": "query",
             "schema": {
               "type": "boolean"
-            },
-            "in": "query"
+            }
           }
         ],
         "requestBody": {
@@ -970,18 +970,18 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           },
           {
             "name": "force",
+            "in": "query",
             "schema": {
               "type": "boolean"
-            },
-            "in": "query"
+            }
           }
         ],
         "requestBody": {
@@ -1063,11 +1063,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -1135,11 +1135,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -1207,19 +1207,19 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           },
           {
             "name": "adapterId",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -1405,11 +1405,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -1457,11 +1457,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "requestBody": {
@@ -1476,19 +1476,25 @@
         },
         "responses": {
           "200": {
-            "description": "Switch updated successfully",
+            "description": "Switch updated or unchanged",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
                     "updated": {
+                      "type": "boolean"
+                    },
+                    "unchanged": {
+                      "type": "boolean"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
                       "type": "string"
                     }
-                  },
-                  "required": [
-                    "updated"
-                  ]
+                  }
                 }
               }
             }
@@ -1537,11 +1543,11 @@
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -1599,11 +1605,11 @@
         "parameters": [
           {
             "name": "name",
+            "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -1769,9 +1775,6 @@
           },
           "vcpu": {
             "type": "integer"
-          },
-          "switchName": {
-            "type": "string"
           },
           "isoPath": {
             "type": "string"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -248,69 +248,12 @@
         }
       },
       "post": {
-        "tags": [
-          "VMs"
-        ],
-        "summary": "Create a new virtual machine",
-        "description": "Creates a new virtual machine. Each call creates a new resource and returns 201 with id (GUID). Names may be duplicated.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VmCreateSchema"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "200": {
             "description": "OK"
           },
           "default": {
             "description": "Internal server error"
-          },
-          "201": {
-            "description": "VM created successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "created": {
-                      "type": "string"
-                    },
-                    "id": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "created",
-                    "id"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid JSON",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorSchema"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Failed to create VM",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorSchema"
-                }
-              }
-            }
           }
         }
       }
@@ -324,12 +267,12 @@
         "description": "Returns detailed information about a specific virtual machine by its GUID",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           }
         ],
         "responses": {
@@ -373,26 +316,36 @@
           "VMs"
         ],
         "summary": "Update a virtual machine",
-        "description": "Updates configuration of an existing virtual machine by Id. VM must be stopped.",
+        "description": "Declaratively update VM configuration (memory, vCPU, ISO). VM must be stopped. Network adapters are managed via PUT /vms/:id/network-adapters.",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           }
         ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/VmUpdateSchema"
+                "type": "object",
+                "properties": {
+                  "memoryMB": {
+                    "type": "integer"
+                  },
+                  "vcpu": {
+                    "type": "integer"
+                  },
+                  "isoPath": {
+                    "type": "string"
+                  }
+                }
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -408,6 +361,9 @@
                     "unchanged": {
                       "type": "boolean"
                     },
+                    "id": {
+                      "type": "string"
+                    },
                     "name": {
                       "type": "string"
                     }
@@ -420,7 +376,7 @@
             "description": "Internal server error"
           },
           "400": {
-            "description": "Invalid JSON",
+            "description": "Invalid JSON or invalid GUID format",
             "content": {
               "application/json": {
                 "schema": {
@@ -440,7 +396,7 @@
             }
           },
           "409": {
-            "description": "Update conflict (e.g., VM is running)",
+            "description": "Update conflict (e.g., VM is running, invalid state)",
             "content": {
               "application/json": {
                 "schema": {
@@ -469,12 +425,12 @@
         "description": "Deletes a virtual machine by Id and its associated virtual hard disks",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           }
         ],
         "responses": {
@@ -531,12 +487,12 @@
         "description": "Returns an array of virtual machines matching the given name (may be 0, 1 or more)",
         "parameters": [
           {
-            "required": true,
+            "name": "name",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "name"
+            "required": true
           }
         ],
         "responses": {
@@ -597,6 +553,248 @@
         }
       }
     },
+    "/vms/{id}/network-adapters": {
+      "get": {
+        "tags": [
+          "VMs"
+        ],
+        "summary": "List network adapters of a virtual machine",
+        "description": "Returns a list of all network adapters for a VM by Id (each adapter includes Id)",
+        "parameters": [
+          {
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of network adapters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "Id": {
+                        "type": "string"
+                      },
+                      "Name": {
+                        "type": "string"
+                      },
+                      "SwitchName": {
+                        "type": "string"
+                      },
+                      "Type": {
+                        "type": "string"
+                      },
+                      "MacAddress": {
+                        "type": "string"
+                      },
+                      "Status": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "Name",
+                      "Type",
+                      "MacAddress"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Internal server error"
+          },
+          "404": {
+            "description": "VM not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to list network adapters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "VMs"
+        ],
+        "summary": "Add a network adapter to a VM",
+        "description": "Adds a network adapter to a virtual machine by Id. Returns 201 with adapter id.",
+        "parameters": [
+          {
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "switchName": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "switchName"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Internal server error"
+          },
+          "201": {
+            "description": "Adapter created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "created": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "VM not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to add adapter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "VMs"
+        ],
+        "summary": "Reconcile VM network adapters",
+        "description": "Declarative update of network adapters for a VM. Body is an array of { name, switchName }. Adapters not in the list are removed; empty array removes all. VM may be running (hot-add/hot-remove).",
+        "parameters": [
+          {
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Adapters updated or unchanged",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "updated": {
+                      "type": "boolean"
+                    },
+                    "unchanged": {
+                      "type": "boolean"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Internal server error"
+          },
+          "400": {
+            "description": "Invalid JSON or adapter list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "VM not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to update network adapters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/vms/{id}/start": {
       "post": {
         "tags": [
@@ -606,12 +804,12 @@
         "description": "Starts a virtual machine by Id. If the VM is paused, it will be resumed",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           }
         ],
         "responses": {
@@ -668,19 +866,19 @@
         "description": "Stops a virtual machine by Id. Use force=true query or body to force shutdown",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           },
           {
+            "name": "force",
             "schema": {
               "type": "boolean"
             },
-            "in": "query",
-            "name": "force"
+            "in": "query"
           }
         ],
         "requestBody": {
@@ -771,19 +969,19 @@
         "description": "Restarts a virtual machine by Id. Use force=true query or body to force shutdown before restart",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           },
           {
+            "name": "force",
             "schema": {
               "type": "boolean"
             },
-            "in": "query",
-            "name": "force"
+            "in": "query"
           }
         ],
         "requestBody": {
@@ -864,12 +1062,12 @@
         "description": "Suspends (pauses) a running virtual machine by Id",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           }
         ],
         "responses": {
@@ -936,12 +1134,12 @@
         "description": "Resumes a suspended virtual machine by Id",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           }
         ],
         "responses": {
@@ -999,172 +1197,6 @@
         }
       }
     },
-    "/vms/{id}/network-adapters": {
-      "get": {
-        "tags": [
-          "VMs"
-        ],
-        "summary": "List network adapters of a virtual machine",
-        "description": "Returns a list of all network adapters for a VM by Id (each adapter includes Id)",
-        "parameters": [
-          {
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of network adapters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "Id": {
-                        "type": "string"
-                      },
-                      "Name": {
-                        "type": "string"
-                      },
-                      "SwitchName": {
-                        "type": "string"
-                      },
-                      "Type": {
-                        "type": "string"
-                      },
-                      "MacAddress": {
-                        "type": "string"
-                      },
-                      "Status": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "Name",
-                      "Type",
-                      "MacAddress"
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "Internal server error"
-          },
-          "404": {
-            "description": "VM not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorSchema"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Failed to list network adapters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorSchema"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "VMs"
-        ],
-        "summary": "Add a network adapter to a VM",
-        "description": "Adds a network adapter to a virtual machine by Id. Returns 201 with adapter id.",
-        "parameters": [
-          {
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "id"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "switchName": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "switchName"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "default": {
-            "description": "Internal server error"
-          },
-          "201": {
-            "description": "Adapter created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "created": {
-                      "type": "string"
-                    },
-                    "id": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "VM not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorSchema"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Failed to add adapter",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorSchema"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/vms/{id}/network-adapters/{adapterId}": {
       "delete": {
         "tags": [
@@ -1174,20 +1206,20 @@
         "description": "Removes a network adapter by adapter Id from a VM by Id",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           },
           {
-            "required": true,
+            "name": "adapterId",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "adapterId"
+            "required": true
           }
         ],
         "responses": {
@@ -1372,12 +1404,12 @@
         "description": "Returns detailed information about a specific virtual switch by its GUID",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           }
         ],
         "responses": {
@@ -1424,12 +1456,12 @@
         "description": "Updates the notes field of an existing virtual switch by Id",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           }
         ],
         "requestBody": {
@@ -1504,12 +1536,12 @@
         "description": "Deletes a virtual switch by Id",
         "parameters": [
           {
-            "required": true,
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "id"
+            "required": true
           }
         ],
         "responses": {
@@ -1566,12 +1598,12 @@
         "description": "Returns an array of virtual switches matching the given name",
         "parameters": [
           {
-            "required": true,
+            "name": "name",
             "schema": {
               "type": "string"
             },
             "in": "path",
-            "name": "name"
+            "required": true
           }
         ],
         "responses": {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -159,49 +159,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
     post:
-      tags:
-        - VMs
-      summary: Create a new virtual machine
-      description: |
-          Creates a new virtual machine. Each call creates a new resource and returns 201
-          with id (GUID). Names may be duplicated.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VmCreateSchema'
-        required: true
       responses:
         200:
           description: OK
         default:
           description: Internal server error
-        201:
-          description: VM created successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  created:
-                    type: string
-                  id:
-                    type: string
-                required:
-                  - created
-                  - id
-        400:
-          description: Invalid JSON
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorSchema'
-        500:
-          description: Failed to create VM
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorSchema'
   /vms/{id}:
     get:
       tags:
@@ -209,11 +171,11 @@ paths:
       summary: Get virtual machine details by Id
       description: Returns detailed information about a specific virtual machine by its GUID
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
+          required: true
       responses:
         200:
           description: Virtual machine details
@@ -239,19 +201,27 @@ paths:
       tags:
         - VMs
       summary: Update a virtual machine
-      description: Updates configuration of an existing virtual machine by Id. VM must be stopped.
+      description: |
+          Declaratively update VM configuration (memory, vCPU, ISO). VM must be stopped.
+          Network adapters are managed via PUT /vms/:id/network-adapters.
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
+          required: true
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VmUpdateSchema'
-        required: true
+              type: object
+              properties:
+                memoryMB:
+                  type: integer
+                vcpu:
+                  type: integer
+                isoPath:
+                  type: string
       responses:
         200:
           description: VM updated successfully or unchanged
@@ -264,12 +234,14 @@ paths:
                     type: boolean
                   unchanged:
                     type: boolean
+                  id:
+                    type: string
                   name:
                     type: string
         default:
           description: Internal server error
         400:
-          description: Invalid JSON
+          description: Invalid JSON or invalid GUID format
           content:
             application/json:
               schema:
@@ -281,7 +253,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
         409:
-          description: Update conflict (e.g., VM is running)
+          description: Update conflict (e.g., VM is running, invalid state)
           content:
             application/json:
               schema:
@@ -298,11 +270,11 @@ paths:
       summary: Delete a virtual machine
       description: Deletes a virtual machine by Id and its associated virtual hard disks
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
+          required: true
       responses:
         200:
           description: VM deleted successfully
@@ -338,11 +310,11 @@ paths:
           Returns an array of virtual machines matching the given name (may be 0, 1 or
           more)
       parameters:
-        - required: true
+        - name: name
           schema:
             type: string
           in: path
-          name: name
+          required: true
       responses:
         200:
           description: Array of VMs with matching name
@@ -380,6 +352,160 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
+  /vms/{id}/network-adapters:
+    get:
+      tags:
+        - VMs
+      summary: List network adapters of a virtual machine
+      description: Returns a list of all network adapters for a VM by Id (each adapter includes Id)
+      parameters:
+        - name: id
+          schema:
+            type: string
+          in: path
+          required: true
+      responses:
+        200:
+          description: List of network adapters
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    Id:
+                      type: string
+                    Name:
+                      type: string
+                    SwitchName:
+                      type: string
+                    Type:
+                      type: string
+                    MacAddress:
+                      type: string
+                    Status:
+                      type: string
+                  required:
+                    - Name
+                    - Type
+                    - MacAddress
+        default:
+          description: Internal server error
+        404:
+          description: VM not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+        500:
+          description: Failed to list network adapters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+    post:
+      tags:
+        - VMs
+      summary: Add a network adapter to a VM
+      description: Adds a network adapter to a virtual machine by Id. Returns 201 with adapter id.
+      parameters:
+        - name: id
+          schema:
+            type: string
+          in: path
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                switchName:
+                  type: string
+              required:
+                - switchName
+        required: true
+      responses:
+        200:
+          description: OK
+        default:
+          description: Internal server error
+        201:
+          description: Adapter created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: string
+                  id:
+                    type: string
+                required:
+                  - id
+        404:
+          description: VM not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+        500:
+          description: Failed to add adapter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+    put:
+      tags:
+        - VMs
+      summary: Reconcile VM network adapters
+      description: |
+          Declarative update of network adapters for a VM. Body is an array of { name,
+          switchName }. Adapters not in the list are removed; empty array removes all. VM
+          may be running (hot-add/hot-remove).
+      parameters:
+        - name: id
+          schema:
+            type: string
+          in: path
+          required: true
+      responses:
+        200:
+          description: Adapters updated or unchanged
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  updated:
+                    type: boolean
+                  unchanged:
+                    type: boolean
+                  id:
+                    type: string
+                  name:
+                    type: string
+        default:
+          description: Internal server error
+        400:
+          description: Invalid JSON or adapter list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+        404:
+          description: VM not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
+        500:
+          description: Failed to update network adapters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchema'
   /vms/{id}/start:
     post:
       tags:
@@ -387,11 +513,11 @@ paths:
       summary: Start a virtual machine
       description: Starts a virtual machine by Id. If the VM is paused, it will be resumed
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
+          required: true
       responses:
         200:
           description: VM started successfully
@@ -425,15 +551,15 @@ paths:
       summary: Stop a virtual machine
       description: Stops a virtual machine by Id. Use force=true query or body to force shutdown
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
-        - schema:
+          required: true
+        - name: force
+          schema:
             type: boolean
           in: query
-          name: force
       requestBody:
         content:
           application/json:
@@ -489,15 +615,15 @@ paths:
           Restarts a virtual machine by Id. Use force=true query or body to force shutdown
           before restart
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
-        - schema:
+          required: true
+        - name: force
+          schema:
             type: boolean
           in: query
-          name: force
       requestBody:
         content:
           application/json:
@@ -545,11 +671,11 @@ paths:
       summary: Suspend a virtual machine
       description: Suspends (pauses) a running virtual machine by Id
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
+          required: true
       responses:
         200:
           description: VM suspended successfully
@@ -589,11 +715,11 @@ paths:
       summary: Resume a virtual machine
       description: Resumes a suspended virtual machine by Id
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
+          required: true
       responses:
         200:
           description: VM resumed successfully
@@ -626,110 +752,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSchema'
-  /vms/{id}/network-adapters:
-    get:
-      tags:
-        - VMs
-      summary: List network adapters of a virtual machine
-      description: Returns a list of all network adapters for a VM by Id (each adapter includes Id)
-      parameters:
-        - required: true
-          schema:
-            type: string
-          in: path
-          name: id
-      responses:
-        200:
-          description: List of network adapters
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Id:
-                      type: string
-                    Name:
-                      type: string
-                    SwitchName:
-                      type: string
-                    Type:
-                      type: string
-                    MacAddress:
-                      type: string
-                    Status:
-                      type: string
-                  required:
-                    - Name
-                    - Type
-                    - MacAddress
-        default:
-          description: Internal server error
-        404:
-          description: VM not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorSchema'
-        500:
-          description: Failed to list network adapters
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorSchema'
-    post:
-      tags:
-        - VMs
-      summary: Add a network adapter to a VM
-      description: Adds a network adapter to a virtual machine by Id. Returns 201 with adapter id.
-      parameters:
-        - required: true
-          schema:
-            type: string
-          in: path
-          name: id
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                switchName:
-                  type: string
-              required:
-                - switchName
-        required: true
-      responses:
-        200:
-          description: OK
-        default:
-          description: Internal server error
-        201:
-          description: Adapter created
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  created:
-                    type: string
-                  id:
-                    type: string
-                required:
-                  - id
-        404:
-          description: VM not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorSchema'
-        500:
-          description: Failed to add adapter
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorSchema'
   /vms/{id}/network-adapters/{adapterId}:
     delete:
       tags:
@@ -737,16 +759,16 @@ paths:
       summary: Remove a network adapter from a VM
       description: Removes a network adapter by adapter Id from a VM by Id
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
-        - required: true
+          required: true
+        - name: adapterId
           schema:
             type: string
           in: path
-          name: adapterId
+          required: true
       responses:
         200:
           description: Adapter removed
@@ -864,11 +886,11 @@ paths:
       summary: Get virtual switch details by Id
       description: Returns detailed information about a specific virtual switch by its GUID
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
+          required: true
       responses:
         200:
           description: Virtual switch details
@@ -896,11 +918,11 @@ paths:
       summary: Update a virtual switch
       description: Updates the notes field of an existing virtual switch by Id
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
+          required: true
       requestBody:
         content:
           application/json:
@@ -945,11 +967,11 @@ paths:
       summary: Delete a virtual switch
       description: Deletes a virtual switch by Id
       parameters:
-        - required: true
+        - name: id
           schema:
             type: string
           in: path
-          name: id
+          required: true
       responses:
         200:
           description: Switch deleted successfully
@@ -983,11 +1005,11 @@ paths:
       summary: Get switches by name
       description: Returns an array of virtual switches matching the given name
       parameters:
-        - required: true
+        - name: name
           schema:
             type: string
           in: path
-          name: name
+          required: true
       responses:
         200:
           description: Array of switches with matching name

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -172,10 +172,10 @@ paths:
       description: Returns detailed information about a specific virtual machine by its GUID
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: Virtual machine details
@@ -206,10 +206,10 @@ paths:
           Network adapters are managed via PUT /vms/:id/network-adapters.
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -271,10 +271,10 @@ paths:
       description: Deletes a virtual machine by Id and its associated virtual hard disks
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: VM deleted successfully
@@ -311,10 +311,10 @@ paths:
           more)
       parameters:
         - name: name
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: Array of VMs with matching name
@@ -360,10 +360,10 @@ paths:
       description: Returns a list of all network adapters for a VM by Id (each adapter includes Id)
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: List of network adapters
@@ -411,10 +411,10 @@ paths:
       description: Adds a network adapter to a virtual machine by Id. Returns 201 with adapter id.
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -466,10 +466,10 @@ paths:
           may be running (hot-add/hot-remove).
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: Adapters updated or unchanged
@@ -514,10 +514,10 @@ paths:
       description: Starts a virtual machine by Id. If the VM is paused, it will be resumed
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: VM started successfully
@@ -552,14 +552,14 @@ paths:
       description: Stops a virtual machine by Id. Use force=true query or body to force shutdown
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
         - name: force
+          in: query
           schema:
             type: boolean
-          in: query
       requestBody:
         content:
           application/json:
@@ -616,14 +616,14 @@ paths:
           before restart
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
         - name: force
+          in: query
           schema:
             type: boolean
-          in: query
       requestBody:
         content:
           application/json:
@@ -672,10 +672,10 @@ paths:
       description: Suspends (pauses) a running virtual machine by Id
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: VM suspended successfully
@@ -716,10 +716,10 @@ paths:
       description: Resumes a suspended virtual machine by Id
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: VM resumed successfully
@@ -760,15 +760,15 @@ paths:
       description: Removes a network adapter by adapter Id from a VM by Id
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
         - name: adapterId
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: Adapter removed
@@ -887,10 +887,10 @@ paths:
       description: Returns detailed information about a specific virtual switch by its GUID
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: Virtual switch details
@@ -919,10 +919,10 @@ paths:
       description: Updates the notes field of an existing virtual switch by Id
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -931,16 +931,20 @@ paths:
         required: true
       responses:
         200:
-          description: Switch updated successfully
+          description: Switch updated or unchanged
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   updated:
+                    type: boolean
+                  unchanged:
+                    type: boolean
+                  id:
                     type: string
-                required:
-                  - updated
+                  name:
+                    type: string
         default:
           description: Internal server error
         400:
@@ -968,10 +972,10 @@ paths:
       description: Deletes a virtual switch by Id
       parameters:
         - name: id
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: Switch deleted successfully
@@ -1006,10 +1010,10 @@ paths:
       description: Returns an array of virtual switches matching the given name
       parameters:
         - name: name
-          schema:
-            type: string
           in: path
           required: true
+          schema:
+            type: string
       responses:
         200:
           description: Array of switches with matching name
@@ -1121,8 +1125,6 @@ components:
           type: integer
         vcpu:
           type: integer
-        switchName:
-          type: string
         isoPath:
           type: string
     VmResponseSchema:

--- a/src/modules/HvoSwitch/HvoSwitch.psm1
+++ b/src/modules/HvoSwitch/HvoSwitch.psm1
@@ -50,9 +50,25 @@ function Set-HvoSwitch {
         }
 
         $swName = $sw.Name
+        $changed = $false
 
         if ($PSBoundParameters.ContainsKey("Notes")) {
-            Set-VMSwitch -Name $swName -Notes $Notes -ErrorAction Stop
+            $currentNotes = $sw.Notes
+            if ($null -eq $currentNotes) { $currentNotes = "" }
+            if ($null -eq $Notes) { $Notes = "" }
+            if ([string]$currentNotes -ne [string]$Notes) {
+                Set-VMSwitch -Name $swName -Notes $Notes -ErrorAction Stop
+                $changed = $true
+            }
+        }
+
+        if (-not $changed) {
+            return @{
+                Updated   = $false
+                Unchanged = $true
+                Name      = $swName
+                Id        = $sw.Id.ToString()
+            }
         }
 
         return @{

--- a/src/modules/HvoVm/HvoVm.psm1
+++ b/src/modules/HvoVm/HvoVm.psm1
@@ -249,36 +249,6 @@ function Get-HvoVm {
     }
 }
 
-# WIP: GUID-based refactor
-# Resource identification is migrating from Name to Id (GUID).
-# This section is part of the canonical Id-based API transition.
-
-
-function Get-HvoVmByName {
-    param(
-        [Parameter(Mandatory)] [string] $Name
-    )
-
-    $vms = @(Get-VM -Name $Name -ErrorAction SilentlyContinue)
-
-    if (-not $vms -or $vms.Count -eq 0) {
-        return @()
-    }
-
-    return $vms | ForEach-Object {
-        [PSCustomObject]@{
-            Id             = $_.Id.Guid
-            Name           = $_.Name
-            State          = $_.State.ToString()
-            CPUUsage       = $_.CPUUsage
-            MemoryAssigned = $_.MemoryAssigned
-            Uptime         = $_.Uptime.ToString()
-        }
-    }
-}
-
-
-
 function Get-HvoVms {
     $vms = Get-VM -ErrorAction SilentlyContinue
     return $vms | ForEach-Object {

--- a/src/modules/HvoVm/HvoVm.psm1
+++ b/src/modules/HvoVm/HvoVm.psm1
@@ -60,9 +60,6 @@ function Set-HvoVm {
         [int] $MemoryMB,
         [int] $Vcpu,
 
-        # Declarative networking: optional on update
-        [array] $NetworkAdapters,
-
         [string] $IsoPath
     )
 
@@ -105,61 +102,6 @@ function Set-HvoVm {
         }
 
         #
-        # NETWORK ADAPTERS — reconcile if provided (authoritative)
-        #
-        if ($PSBoundParameters.ContainsKey("NetworkAdapters")) {
-
-            # Normalize/validate desired adapters
-            $desired = @{}
-            foreach ($a in $NetworkAdapters) {
-                if (-not $a.name -or -not $a.switchName) {
-                    throw "Each networkAdapters item must contain 'name' and 'switchName'"
-                }
-
-                $n = [string]$a.name
-                $s = [string]$a.switchName
-
-                if ($desired.ContainsKey($n)) {
-                    throw "Duplicate network adapter name in request: '$n'"
-                }
-
-                $desired[$n] = $s
-            }
-
-            # Current adapters indexed by Name
-            $currentList = @(Get-VMNetworkAdapter -VMName $vm.Name -ErrorAction Stop)
-            $current = @{}
-            foreach ($c in $currentList) {
-                $current[$c.Name] = $c
-            }
-
-            # Remove adapters not desired
-            foreach ($name in @($current.Keys)) {
-                if (-not $desired.ContainsKey($name)) {
-                    Remove-VMNetworkAdapter -VMNetworkAdapter $current[$name] -Confirm:$false -ErrorAction Stop
-                    $changed = $true
-                }
-            }
-
-            # Add or reconnect desired adapters
-            foreach ($name in $desired.Keys) {
-                $targetSwitch = $desired[$name]
-
-                if (-not $current.ContainsKey($name)) {
-                    Add-VMNetworkAdapter -VMName $vm.Name -Name $name -SwitchName $targetSwitch -ErrorAction Stop
-                    $changed = $true
-                    continue
-                }
-
-                $cur = $current[$name]
-                if ($cur.SwitchName -ne $targetSwitch) {
-                    Connect-VMNetworkAdapter -VMNetworkAdapter $cur -SwitchName $targetSwitch -ErrorAction Stop
-                    $changed = $true
-                }
-            }
-        }
-
-        #
         # ISO — update only if different
         #
         if ($PSBoundParameters.ContainsKey("IsoPath")) {
@@ -197,9 +139,92 @@ function Set-HvoVm {
     }
 }
 
+#
+# Declarative reconciliation of VM network adapters (hot-add/hot-remove allowed).
+# Used by PUT /vms/:id/network-adapters. VM may be running.
+#
+function Set-HvoVmNetworkAdapters {
+    param(
+        [Parameter(Mandatory)] [Guid] $Id,
+        [array] $NetworkAdapters = @()
+    )
 
+    try {
+        $vm = Get-VM -Id $Id -ErrorAction SilentlyContinue
+        if (-not $vm) {
+            return @{ Updated = $false; Error = "VM not found"; Id = "$Id" }
+        }
 
+        # Normalize/validate desired adapters
+        $desired = @{}
+        foreach ($a in $NetworkAdapters) {
+            if (-not $a.name -or -not $a.switchName) {
+                throw "Each networkAdapters item must contain 'name' and 'switchName'"
+            }
 
+            $n = [string]$a.name
+            $s = [string]$a.switchName
+
+            if ($desired.ContainsKey($n)) {
+                throw "Duplicate network adapter name in request: '$n'"
+            }
+
+            $desired[$n] = $s
+        }
+
+        $changed = $false
+
+        # Current adapters indexed by Name
+        $currentList = @(Get-VMNetworkAdapter -VMName $vm.Name -ErrorAction Stop)
+        $current = @{}
+        foreach ($c in $currentList) {
+            $current[$c.Name] = $c
+        }
+
+        # Remove adapters not desired
+        foreach ($name in @($current.Keys)) {
+            if (-not $desired.ContainsKey($name)) {
+                Remove-VMNetworkAdapter -VMName $vm.Name -Name $name -Confirm:$false -ErrorAction Stop
+                $changed = $true
+            }
+        }
+
+        # Add or reconnect desired adapters
+        foreach ($name in $desired.Keys) {
+            $targetSwitch = $desired[$name]
+
+            if (-not $current.ContainsKey($name)) {
+                Add-VMNetworkAdapter -VMName $vm.Name -Name $name -SwitchName $targetSwitch -ErrorAction Stop
+                $changed = $true
+                continue
+            }
+
+            $cur = $current[$name]
+            if ($cur.SwitchName -ne $targetSwitch) {
+                Connect-VMNetworkAdapter -VMName $vm.Name -Name $cur.Name -SwitchName $targetSwitch -ErrorAction Stop
+                $changed = $true
+            }
+        }
+
+        if (-not $changed) {
+            return @{
+                Updated   = $false
+                Unchanged = $true
+                Id        = "$Id"
+                Name      = $vm.Name
+            }
+        }
+
+        return @{
+            Updated = $true
+            Id      = "$Id"
+            Name    = $vm.Name
+        }
+    }
+    catch {
+        throw
+    }
+}
 
 function Get-HvoVm {
     param(
@@ -643,7 +668,7 @@ function Get-HvoVmNetworkAdapters {
             return $null
         }
 
-        $adapters = Get-VMNetworkAdapter -VM $vm -ErrorAction SilentlyContinue
+        $adapters = Get-VMNetworkAdapter -VMName $vm.Name -ErrorAction SilentlyContinue
         if (-not $adapters) {
             return @()
         }
@@ -724,7 +749,7 @@ function Remove-HvoVmNetworkAdapter {
             return $false
         }
 
-        $adapters = Get-VMNetworkAdapter -VM $vm -ErrorAction SilentlyContinue
+        $adapters = Get-VMNetworkAdapter -VMName $vm.Name -ErrorAction SilentlyContinue
         if (-not $adapters) {
             return $false
         }
@@ -741,7 +766,7 @@ function Remove-HvoVmNetworkAdapter {
             return $false
         }
 
-        Remove-VMNetworkAdapter -VMNetworkAdapter $adapter -ErrorAction Stop
+        Remove-VMNetworkAdapter -VMName $vm.Name -Name $adapter.Name -ErrorAction Stop
         return $true
     }
     catch {

--- a/src/routes/switches.ps1
+++ b/src/routes/switches.ps1
@@ -178,16 +178,25 @@ function global:Add-HvoSwitchRoutes {
             }
 
             $params = @{ Id = $id }
-            if ($body.notes) { $params.Notes = $body.notes }
+            if ($null -ne $body.notes) { $params.Notes = $body.notes }
 
             $result = Set-HvoSwitch @params
 
-            if (-not $result.Updated) {
+            if ($result.Error -eq "Switch not found") {
                 Write-PodeJsonResponse -StatusCode 404 -Value $result
                 return
             }
 
-            Write-PodeJsonResponse -Value @{ updated = $result.Name; id = $result.Id }
+            if ($result.Unchanged) {
+                Write-PodeJsonResponse -StatusCode 200 -Value @{
+                    unchanged = $true
+                    id        = $result.Id
+                    name      = $result.Name
+                }
+                return
+            }
+
+            Write-PodeJsonResponse -StatusCode 200 -Value @{ updated = $true; id = $result.Id; name = $result.Name }
         }
         catch {
             Write-PodeJsonResponse -StatusCode 500 -Value @{
@@ -203,9 +212,12 @@ function global:Add-HvoSwitchRoutes {
     ) -RequestBody (New-PodeOARequestBody -ContentSchemas @{
         'application/json' = 'SwitchUpdateSchema'
     } -Required)
-    $route | Add-PodeOAResponse -StatusCode 200 -Description 'Switch updated successfully' -ContentSchemas @{
+    $route | Add-PodeOAResponse -StatusCode 200 -Description 'Switch updated or unchanged' -ContentSchemas @{
         'application/json' = (New-PodeOAObjectProperty -Properties @(
-            (New-PodeOAStringProperty -Name 'updated' -Required)
+            (New-PodeOABoolProperty -Name 'updated'),
+            (New-PodeOABoolProperty -Name 'unchanged'),
+            (New-PodeOAStringProperty -Name 'id'),
+            (New-PodeOAStringProperty -Name 'name')
         ))
     }
     $route | Add-PodeOAResponse -StatusCode 400 -Description 'Invalid JSON' -ContentSchemas @{

--- a/src/routes/vms.ps1
+++ b/src/routes/vms.ps1
@@ -1,4 +1,4 @@
-﻿function global:Add-HvoVmRoutes {
+function global:Add-HvoVmRoutes {
     # Define reusable OpenAPI component schemas for VMs
     Add-PodeOAComponentSchema -Name 'VmSchema' -Schema (
         New-PodeOAObjectProperty -Properties @(
@@ -202,13 +202,12 @@
             return
         }
 
-        # Only pass parameters actually provided by the client
+        # Only pass parameters actually provided by the client (VM config only; network adapters use PUT /vms/:id/network-adapters)
         $params = @{ Id = $id }
 
-        if ($null -ne $body.memoryMB)        { $params.MemoryMB        = [int]$body.memoryMB }
-        if ($null -ne $body.vcpu)            { $params.Vcpu            = [int]$body.vcpu }
-        if ($null -ne $body.isoPath)         { $params.IsoPath         = [string]$body.isoPath }
-        if ($null -ne $body.networkAdapters) { $params.NetworkAdapters = $body.networkAdapters }
+        if ($null -ne $body.memoryMB) { $params.MemoryMB = [int]$body.memoryMB }
+        if ($null -ne $body.vcpu)     { $params.Vcpu    = [int]$body.vcpu }
+        if ($null -ne $body.isoPath)  { $params.IsoPath = [string]$body.isoPath }
 
         $result = Set-HvoVm @params
 
@@ -249,17 +248,13 @@
     }
 } -PassThru
 
-    $route | Set-PodeOARouteInfo -Summary 'Update a virtual machine' -Description 'Declaratively update VM configuration (memory, vCPU, network adapters, ISO). Aligns current state to desired state. Fully idempotent. VM must be stopped.' -Tags @('VMs')
+    $route | Set-PodeOARouteInfo -Summary 'Update a virtual machine' -Description 'Declaratively update VM configuration (memory, vCPU, ISO). VM must be stopped. Network adapters are managed via PUT /vms/:id/network-adapters.' -Tags @('VMs')
     $route | Set-PodeOARequest -Parameters @(
         (New-PodeOAStringProperty -Name 'id' -Required | ConvertTo-PodeOAParameter -In Path)
     ) -RequestBody (New-PodeOARequestBody -ContentSchemas @{
         'application/json' = (New-PodeOAObjectProperty -Properties @(
             (New-PodeOAIntProperty -Name 'memoryMB'),
             (New-PodeOAIntProperty -Name 'vcpu'),
-            (New-PodeOAObjectProperty -Name 'networkAdapters' -Array -Properties @(
-                (New-PodeOAStringProperty -Name 'name' -Required),
-                (New-PodeOAStringProperty -Name 'switchName' -Required)
-            )),
             (New-PodeOAStringProperty -Name 'isoPath')
         ))
     })
@@ -283,6 +278,87 @@
     $route | Add-PodeOAResponse -StatusCode 500 -Description 'Failed to update VM' -ContentSchemas @{
         'application/json' = 'ErrorSchema'
     }
+
+    #
+    # PUT /vms/:id/network-adapters — declarative reconciliation (hot-add/hot-remove allowed)
+    #
+    $route = Add-PodeRoute -Method Put -Path '/vms/:id/network-adapters' -ScriptBlock {
+        try {
+            $idRaw = $WebEvent.Parameters['id']
+            try { $id = [Guid]$idRaw }
+            catch {
+                Write-PodeJsonResponse -StatusCode 400 -Value @{ error = "Invalid VM id (expected GUID)" }
+                return
+            }
+
+            $body = Get-HvoJsonBody
+            if ($null -eq $body) {
+                Write-PodeJsonResponse -StatusCode 400 -Value @{ error = "Invalid JSON" }
+                return
+            }
+            $adapters = @($body)
+            if ($adapters.Count -eq 1 -and $null -eq $adapters[0]) {
+                $adapters = @()
+            }
+
+            $result = Set-HvoVmNetworkAdapters -Id $id -NetworkAdapters $adapters
+
+            if ($result.Error -eq "VM not found") {
+                Write-PodeJsonResponse -StatusCode 404 -Value $result
+                return
+            }
+
+            if ($result.Updated -eq $false -and $result.Unchanged) {
+                Write-PodeJsonResponse -StatusCode 200 -Value @{
+                    unchanged = $true
+                    id        = "$id"
+                    name      = $result.Name
+                }
+                return
+            }
+
+            if ($result.Updated -eq $true) {
+                Write-PodeJsonResponse -StatusCode 200 -Value @{
+                    updated = $true
+                    id      = "$id"
+                    name    = $result.Name
+                }
+                return
+            }
+
+            Write-PodeJsonResponse -StatusCode 500 -Value @{
+                error  = "Failed to update network adapters"
+                detail = if ($result.Error) { $result.Error } else { "Unknown error" }
+            }
+        }
+        catch {
+            $msg = $_.Exception.Message
+            if ($msg -match "name.*switchName|Duplicate network adapter") {
+                Write-PodeJsonResponse -StatusCode 400 -Value @{ error = $msg }
+                return
+            }
+            Write-PodeJsonResponse -StatusCode 500 -Value @{
+                error  = "Failed to update network adapters"
+                detail = $msg
+            }
+        }
+    } -PassThru
+
+    $route | Set-PodeOARouteInfo -Summary 'Reconcile VM network adapters' -Description 'Declarative update of network adapters for a VM. Body is an array of { name, switchName }. Adapters not in the list are removed; empty array removes all. VM may be running (hot-add/hot-remove).' -Tags @('VMs')
+    $route | Set-PodeOARequest -Parameters @(
+        (New-PodeOAStringProperty -Name 'id' -Required | ConvertTo-PodeOAParameter -In Path)
+    )
+    $route | Add-PodeOAResponse -StatusCode 200 -Description 'Adapters updated or unchanged' -ContentSchemas @{
+        'application/json' = (New-PodeOAObjectProperty -Properties @(
+            (New-PodeOABoolProperty -Name 'updated'),
+            (New-PodeOABoolProperty -Name 'unchanged'),
+            (New-PodeOAStringProperty -Name 'id'),
+            (New-PodeOAStringProperty -Name 'name')
+        ))
+    }
+    $route | Add-PodeOAResponse -StatusCode 400 -Description 'Invalid JSON or adapter list' -ContentSchemas @{ 'application/json' = 'ErrorSchema' }
+    $route | Add-PodeOAResponse -StatusCode 404 -Description 'VM not found' -ContentSchemas @{ 'application/json' = 'ErrorSchema' }
+    $route | Add-PodeOAResponse -StatusCode 500 -Description 'Failed to update network adapters' -ContentSchemas @{ 'application/json' = 'ErrorSchema' }
 
     #
     # DELETE /vms/:id

--- a/src/routes/vms.ps1
+++ b/src/routes/vms.ps1
@@ -27,7 +27,6 @@ function global:Add-HvoVmRoutes {
         New-PodeOAObjectProperty -Properties @(
             (New-PodeOAIntProperty -Name 'memoryMB'),
             (New-PodeOAIntProperty -Name 'vcpu'),
-            (New-PodeOAStringProperty -Name 'switchName'),
             (New-PodeOAStringProperty -Name 'isoPath')
         )
     )
@@ -186,67 +185,67 @@ function global:Add-HvoVmRoutes {
     # PUT /vms/:id - Declarative VM Update
     #
     $route = Add-PodeRoute -Method Put -Path '/vms/:id' -ScriptBlock {
-    try {
-        $idRaw = $WebEvent.Parameters['id']
+        try {
+            $idRaw = $WebEvent.Parameters['id']
 
-        # Validate GUID
-        try { $id = [Guid]$idRaw }
-        catch {
-            Write-PodeJsonResponse -StatusCode 400 -Value @{ error = "Invalid VM id (expected GUID)" }
-            return
-        }
-
-        $body = Get-HvoJsonBody
-        if (-not $body) {
-            Write-PodeJsonResponse -StatusCode 400 -Value @{ error = "Invalid JSON" }
-            return
-        }
-
-        # Only pass parameters actually provided by the client (VM config only; network adapters use PUT /vms/:id/network-adapters)
-        $params = @{ Id = $id }
-
-        if ($null -ne $body.memoryMB) { $params.MemoryMB = [int]$body.memoryMB }
-        if ($null -ne $body.vcpu)     { $params.Vcpu    = [int]$body.vcpu }
-        if ($null -ne $body.isoPath)  { $params.IsoPath = [string]$body.isoPath }
-
-        $result = Set-HvoVm @params
-
-        # 404
-        if ($result.Error -eq "VM not found") {
-            Write-PodeJsonResponse -StatusCode 404 -Value $result
-            return
-        }
-
-        # unchanged (idempotent)
-        if ($result.Updated -eq $false -and $result.Unchanged) {
-            Write-PodeJsonResponse -StatusCode 200 -Value @{
-                unchanged = $true
-                id        = "$id"
-                name      = $result.Name
+            # Validate GUID
+            try { $id = [Guid]$idRaw }
+            catch {
+                Write-PodeJsonResponse -StatusCode 400 -Value @{ error = "Invalid VM id (expected GUID)" }
+                return
             }
-            return
-        }
 
-        # conflict (eg running)
-        if ($result.Updated -eq $false -and $result.Error) {
-            Write-PodeJsonResponse -StatusCode 409 -Value $result
-            return
-        }
+            $body = Get-HvoJsonBody
+            if (-not $body) {
+                Write-PodeJsonResponse -StatusCode 400 -Value @{ error = "Invalid JSON" }
+                return
+            }
 
-        # updated
-        Write-PodeJsonResponse -StatusCode 200 -Value @{
-            updated = $true
-            id      = "$id"
-            name    = $result.Name
+            # Only pass parameters actually provided by the client (VM config only; network adapters use PUT /vms/:id/network-adapters)
+            $params = @{ Id = $id }
+
+            if ($null -ne $body.memoryMB) { $params.MemoryMB = [int]$body.memoryMB }
+            if ($null -ne $body.vcpu)     { $params.Vcpu    = [int]$body.vcpu }
+            if ($null -ne $body.isoPath)  { $params.IsoPath = [string]$body.isoPath }
+
+            $result = Set-HvoVm @params
+
+            # 404
+            if ($result.Error -eq "VM not found") {
+                Write-PodeJsonResponse -StatusCode 404 -Value $result
+                return
+            }
+
+            # unchanged (idempotent)
+            if ($result.Updated -eq $false -and $result.Unchanged) {
+                Write-PodeJsonResponse -StatusCode 200 -Value @{
+                    unchanged = $true
+                    id        = "$id"
+                    name      = $result.Name
+                }
+                return
+            }
+
+            # conflict (eg running)
+            if ($result.Updated -eq $false -and $result.Error) {
+                Write-PodeJsonResponse -StatusCode 409 -Value $result
+                return
+            }
+
+            # updated
+            Write-PodeJsonResponse -StatusCode 200 -Value @{
+                updated = $true
+                id      = "$id"
+                name    = $result.Name
+            }
         }
-    }
-    catch {
-        Write-PodeJsonResponse -StatusCode 500 -Value @{
-            error  = "Failed to update VM"
-            detail = $_.Exception.Message
+        catch {
+            Write-PodeJsonResponse -StatusCode 500 -Value @{
+                error  = "Failed to update VM"
+                detail = $_.Exception.Message
+            }
         }
-    }
-} -PassThru
+    } -PassThru
 
     $route | Set-PodeOARouteInfo -Summary 'Update a virtual machine' -Description 'Declaratively update VM configuration (memory, vCPU, ISO). VM must be stopped. Network adapters are managed via PUT /vms/:id/network-adapters.' -Tags @('VMs')
     $route | Set-PodeOARequest -Parameters @(

--- a/tests/run-api-tests.ps1
+++ b/tests/run-api-tests.ps1
@@ -33,7 +33,7 @@ function Invoke-ApiRequest {
         [string]$Method,
         [string]$Path,
         [int[]]$ExpectedStatus = @(200),
-        [hashtable]$Body = $null,
+        [object]$Body = $null,
         [string]$TestName = "$Method $Path"
     )
     $url = "$BaseUrl$Path"
@@ -116,6 +116,9 @@ Add-Report "[OK] Serveur accessible (GET /health -> $($healthResult.StatusCode))
 Add-Report ""
 
 $startTime = Get-Date
+$script:runFailed = $false
+
+try {
 
 # ========== Phase 1: Basic ==========
 Add-Report "--- Phase 1: Health et documentation ---" ""
@@ -211,6 +214,10 @@ if (-not $script:SwitchId) {
         Add-Report "  [$(if ($r.Success) { 'OK' } else { 'FAIL' })] $($r.TestName) -> $($r.StatusCode)" "  "
         if (-not $r.Success) { Add-Report "      Response: $($r.Content)" "  " }
 
+        # Issue #25: PUT /vms/:id (VM config) must return 409 when VM is running
+        $r = Invoke-ApiRequest -Method Put -Path "/vms/$($script:VmId)" -Body @{ memoryMB = 512; vcpu = 1 } -ExpectedStatus 409 -TestName 'PUT /vms/:id on running VM returns 409 (issue #25)'
+        Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+
         $r = Invoke-ApiRequest -Method Post -Path "/vms/$($script:VmId)/stop" -Body @{ force = $true } -ExpectedStatus 200 -TestName 'POST /vms/:id/stop'
         Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
 
@@ -228,8 +235,39 @@ if (-not $script:SwitchId) {
 
         $r = Invoke-ApiRequest -Method Get -Path "/vms/$($script:VmId)/network-adapters" -ExpectedStatus 200 -TestName 'GET /vms/:id/network-adapters'
         Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+        $adaptersBeforePutVm = if ($r.Success -and $r.Json) { @($r.Json).Count } else { 0 }
 
         $r = Invoke-ApiRequest -Method Put -Path "/vms/$($script:VmId)" -Body @{ memoryMB = 512; vcpu = 1 } -ExpectedStatus 200 -TestName 'PUT /vms/:id'
+        Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+
+        # Issue #25: PUT /vms/:id must not change network adapters (declarative adapters are via PUT /vms/:id/network-adapters only)
+        $r = Invoke-ApiRequest -Method Get -Path "/vms/$($script:VmId)/network-adapters" -ExpectedStatus 200 -TestName 'GET /vms/:id/network-adapters after PUT /vms/:id (adapters unchanged, issue #25)'
+        if ($r.Success -and $r.Json) {
+            $countAfter = @($r.Json).Count
+            if ($countAfter -ne $adaptersBeforePutVm) {
+                $r.Success = $false
+                $r.Content = "Expected $adaptersBeforePutVm adapter(s) unchanged after PUT /vms/:id, got $countAfter (issue #25)"
+                $null = $failedTests.Add(@{ Phase = 'Phase3'; Result = $r })
+                $script:passedTests--
+            }
+        }
+        Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+
+        # Issue #25: Declarative reconciliation via PUT /vms/:id/network-adapters
+        $desiredAdapters = @(@{ name = 'Ethernet'; switchName = $testSwitchName })
+        $r = Invoke-ApiRequest -Method Put -Path "/vms/$($script:VmId)/network-adapters" -Body $desiredAdapters -ExpectedStatus 200 -TestName 'PUT /vms/:id/network-adapters (declarative, issue #25)'
+        Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
+
+        $r = Invoke-ApiRequest -Method Get -Path "/vms/$($script:VmId)/network-adapters" -ExpectedStatus 200 -TestName 'GET /vms/:id/network-adapters after PUT (reconciled list)'
+        if ($r.Success -and $r.Json) {
+            $list = @($r.Json)
+            if ($list.Count -ne 1) {
+                $r.Success = $false
+                $r.Content = "Expected 1 adapter after PUT /vms/:id/network-adapters, got $($list.Count)"
+                $null = $failedTests.Add(@{ Phase = 'Phase3'; Result = $r })
+                $script:passedTests--
+            }
+        }
         Add-TestResult -Result $r -Phase 'Phase3' | Out-Null
 
         $r = Invoke-ApiRequest -Method Delete -Path "/vms/$($script:VmId)" -ExpectedStatus 200 -TestName 'DELETE /vms/:id'
@@ -243,9 +281,17 @@ if (-not $script:SwitchId) {
     }
 }
 
-# ----- Report -----
+} catch {
+    $script:runFailed = $true
+    Add-Report "" ""
+    Add-Report "--- Erreur (exception non geree) ---" ""
+    Add-Report $_.Exception.Message ""
+    Add-Report "Emplacement: $($_.ScriptStackTrace)" ""
+}
+
+# ----- Report (toujours affiche, y compris en cas d'exception) -----
 $endTime = Get-Date
-$duration = $endTime - $startTime
+$duration = if ($startTime) { $endTime - $startTime } else { [TimeSpan]::Zero }
 Add-Report "" ""
 Add-Report "=== Rapport ===" ""
 Add-Report "Date/heure: $($endTime.ToString('yyyy-MM-dd HH:mm:ss'))" ""
@@ -258,6 +304,8 @@ if ($failedTests.Count -gt 0) {
         Add-Report "  - $($f.Result.TestName)" ""
         Add-Report "    HTTP $($f.Result.StatusCode) | $($f.Result.Content)" ""
     }
+}
+if ($failedTests.Count -gt 0 -or $script:runFailed) {
     Add-Report "" ""
     Add-Report "--- Remise en condition initiale Hyper-V ---" ""
     Add-Report "Si des ressources de test sont restees, supprimez-les avec PowerShell (en administrateur):" ""
@@ -288,7 +336,7 @@ $reportLines -join "`n" | Set-Content -Path $reportFile -Encoding UTF8
 Add-Report "" ""
 Add-Report "Rapport enregistre: $reportFile" ""
 
-if ($failedTests.Count -gt 0) {
+if ($failedTests.Count -gt 0 -or $script:runFailed) {
     exit 1
 }
 exit 0

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -112,17 +112,23 @@ if ($runUnit) {
     }
 }
 
-# Run integration tests
+# Run integration tests (only if test files exist)
 if ($runIntegration) {
-    Write-Host "`n=== Integration Tests ===" -ForegroundColor Cyan
-    $integrationConfig = New-PesterConfiguration
-    $integrationConfig.Run.Path = $integrationPath
-    $integrationConfig.Output.Verbosity = 'Detailed'
+    $integrationTestFiles = Get-ChildItem -Path $integrationPath -Filter "*.Tests.ps1" -Recurse -ErrorAction SilentlyContinue
+    if ($integrationTestFiles.Count -gt 0) {
+        Write-Host "`n=== Integration Tests ===" -ForegroundColor Cyan
+        $integrationConfig = New-PesterConfiguration
+        $integrationConfig.Run.Path = $integrationPath
+        $integrationConfig.Output.Verbosity = 'Detailed'
 
-    $integrationResults = Invoke-Pester -Configuration $integrationConfig
+        $integrationResults = Invoke-Pester -Configuration $integrationConfig
 
-    if ($integrationResults.FailedCount -gt 0) {
-        $allPassed = $false
+        if ($integrationResults.FailedCount -gt 0) {
+            $allPassed = $false
+        }
+    } else {
+        Write-Host "`n=== Integration Tests ===" -ForegroundColor Cyan
+        Write-Host "No integration test files (*.Tests.ps1) found in $integrationPath, skipping." -ForegroundColor Gray
     }
 }
 

--- a/tests/unit/HvoSwitch.Tests.ps1
+++ b/tests/unit/HvoSwitch.Tests.ps1
@@ -2,20 +2,11 @@
 # Uses InModuleScope to test within the module context and allow mocks to work
 
 BeforeAll {
-    # Create stubs for Hyper-V cmdlets when they are not present (e.g. WSL, Linux)
-    # This allows Pester to mock these commands even without the Hyper-V module
-    if (-not (Get-Command Get-VMSwitch -ErrorAction SilentlyContinue)) {
-        function global:Get-VMSwitch { param($Name, $Id, $ErrorAction) }
-    }
-    if (-not (Get-Command New-VMSwitch -ErrorAction SilentlyContinue)) {
-        function global:New-VMSwitch { param($Name, $SwitchType, $NetAdapterName, $AllowManagementOS) }
-    }
-    if (-not (Get-Command Set-VMSwitch -ErrorAction SilentlyContinue)) {
-        function global:Set-VMSwitch { param($Name, $Notes, $ErrorAction) }
-    }
-    if (-not (Get-Command Remove-VMSwitch -ErrorAction SilentlyContinue)) {
-        function global:Remove-VMSwitch { param($Name, $Force, $ErrorAction) }
-    }
+    # Always define stubs so that Pester mocks apply (avoids type constraints of real Hyper-V cmdlets on Windows)
+    function global:Get-VMSwitch { param($Name, $Id, $ErrorAction) }
+    function global:New-VMSwitch { param($Name, $SwitchType, $NetAdapterName, $AllowManagementOS) }
+    function global:Set-VMSwitch { param($Name, $Notes, $ErrorAction) }
+    function global:Remove-VMSwitch { param($Name, $Force, $ErrorAction) }
 
     $modulePath = Join-Path $PSScriptRoot "../../src/modules/HvoSwitch/HvoSwitch.psd1"
     Import-Module $modulePath -Force
@@ -99,21 +90,21 @@ InModuleScope HvoSwitch {
                 }
                 $mockSwitch.SwitchType | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return "Internal" } -Force
 
-                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $mockSwitch }
+                Mock Get-VMSwitch -ParameterFilter { $null -ne $Id -and $Id.ToString() -eq $script:testSwitchGuid.ToString() } -MockWith { return $mockSwitch }
 
                 $result = Get-HvoSwitch -Id $switchId.ToString()
 
                 $result | Should -Not -BeNullOrEmpty
                 $result.Id | Should -Be $switchId.ToString()
                 $result.Name | Should -Be "test-switch"
-                Should -Invoke Get-VMSwitch -Exactly -Times 1 -ParameterFilter { $Id -eq $switchId }
+                Should -Invoke Get-VMSwitch -Exactly -Times 1 -ParameterFilter { $null -ne $Id -and $Id.ToString() -eq $script:testSwitchGuid.ToString() }
             }
         }
 
         Context "When the switch does not exist" {
             It "Should return null" {
                 $switchId = [guid]'00000000-0000-0000-0000-000000000001'
-                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $null }
+                Mock Get-VMSwitch -ParameterFilter { $null -ne $Id -and $Id.ToString() -eq $switchId.ToString() } -MockWith { return $null }
                 $result = Get-HvoSwitch -Id $switchId.ToString()
                 $result | Should -BeNullOrEmpty
             }
@@ -177,7 +168,7 @@ InModuleScope HvoSwitch {
         Context "When the switch does not exist" {
             It "Should return Updated = false with an error" {
                 $switchId = [guid]'00000000-0000-0000-0000-000000000001'
-                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $null }
+                Mock Get-VMSwitch -ParameterFilter { $null -ne $Id -and $Id.ToString() -eq $switchId.ToString() } -MockWith { return $null }
                 Mock Set-VMSwitch -MockWith { }
                 $result = Set-HvoSwitch -Id $switchId.ToString() -Notes "New notes"
                 $result | Should -Not -BeNullOrEmpty
@@ -192,7 +183,7 @@ InModuleScope HvoSwitch {
                 $switchId = $script:testSwitchGuid
                 $newNotes = "Updated notes"
                 $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "existing-switch" }
-                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $mockSwitch }
+                Mock Get-VMSwitch -ParameterFilter { $null -ne $Id -and $Id.ToString() -eq $script:testSwitchGuid.ToString() } -MockWith { return $mockSwitch }
                 Mock Set-VMSwitch -MockWith { }
                 $result = Set-HvoSwitch -Id $switchId.ToString() -Notes $newNotes
                 $result | Should -Not -BeNullOrEmpty
@@ -206,7 +197,7 @@ InModuleScope HvoSwitch {
             It "Should return Updated = true even without modification if the switch exists" {
                 $switchId = $script:testSwitchGuid
                 $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "existing-switch" }
-                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $mockSwitch }
+                Mock Get-VMSwitch -ParameterFilter { $null -ne $Id -and $Id.ToString() -eq $script:testSwitchGuid.ToString() } -MockWith { return $mockSwitch }
                 Mock Set-VMSwitch -MockWith { }
                 $result = Set-HvoSwitch -Id $switchId.ToString()
                 $result | Should -Not -BeNullOrEmpty
@@ -220,7 +211,7 @@ InModuleScope HvoSwitch {
             It "Should propagate the exception" {
                 $switchId = $script:testSwitchGuid
                 $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "switch-with-error" }
-                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $mockSwitch }
+                Mock Get-VMSwitch -ParameterFilter { $null -ne $Id -and $Id.ToString() -eq $script:testSwitchGuid.ToString() } -MockWith { return $mockSwitch }
                 Mock Set-VMSwitch -MockWith { throw "Test error" }
                 { Set-HvoSwitch -Id $switchId.ToString() -Notes "Test" } | Should -Throw
             }
@@ -231,7 +222,7 @@ InModuleScope HvoSwitch {
         Context "When the switch does not exist" {
             It "Should return false" {
                 $switchId = [guid]'00000000-0000-0000-0000-000000000001'
-                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $null }
+                Mock Get-VMSwitch -ParameterFilter { $null -ne $Id -and $Id.ToString() -eq $switchId.ToString() } -MockWith { return $null }
                 Mock Remove-VMSwitch -MockWith { }
                 $result = Remove-HvoSwitch -Id $switchId.ToString()
                 $result | Should -Be $false
@@ -243,7 +234,7 @@ InModuleScope HvoSwitch {
             It "Should remove the switch" {
                 $switchId = $script:testSwitchGuid
                 $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "existing-switch" }
-                Mock Get-VMSwitch -ParameterFilter { $Id -eq $switchId } -MockWith { return $mockSwitch }
+                Mock Get-VMSwitch -ParameterFilter { $null -ne $Id -and $Id.ToString() -eq $script:testSwitchGuid.ToString() } -MockWith { return $mockSwitch }
                 Mock Remove-VMSwitch -MockWith { }
                 $result = Remove-HvoSwitch -Id $switchId.ToString()
                 $result | Should -Be $true

--- a/tests/unit/HvoSwitch.Tests.ps1
+++ b/tests/unit/HvoSwitch.Tests.ps1
@@ -194,15 +194,27 @@ InModuleScope HvoSwitch {
                 }
             }
 
-            It "Should return Updated = true even without modification if the switch exists" {
+            It "Should return Unchanged when no Notes parameter or notes unchanged" {
                 $switchId = $script:testSwitchGuid
-                $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "existing-switch" }
+                $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "existing-switch"; Notes = "same" }
                 Mock Get-VMSwitch -ParameterFilter { $null -ne $Id -and $Id.ToString() -eq $script:testSwitchGuid.ToString() } -MockWith { return $mockSwitch }
                 Mock Set-VMSwitch -MockWith { }
                 $result = Set-HvoSwitch -Id $switchId.ToString()
                 $result | Should -Not -BeNullOrEmpty
-                $result.Updated | Should -Be $true
+                $result.Updated | Should -Be $false
+                $result.Unchanged | Should -Be $true
                 $result.Name | Should -Be "existing-switch"
+                Should -Not -Invoke Set-VMSwitch
+            }
+
+            It "Should return Unchanged when Notes value equals current" {
+                $switchId = $script:testSwitchGuid
+                $mockSwitch = [PSCustomObject]@{ Id = $switchId; Name = "existing-switch"; Notes = "same" }
+                Mock Get-VMSwitch -ParameterFilter { $null -ne $Id -and $Id.ToString() -eq $script:testSwitchGuid.ToString() } -MockWith { return $mockSwitch }
+                Mock Set-VMSwitch -MockWith { }
+                $result = Set-HvoSwitch -Id $switchId.ToString() -Notes "same"
+                $result.Updated | Should -Be $false
+                $result.Unchanged | Should -Be $true
                 Should -Not -Invoke Set-VMSwitch
             }
         }

--- a/tests/unit/HvoVm.Tests.ps1
+++ b/tests/unit/HvoVm.Tests.ps1
@@ -2,71 +2,29 @@
 # Uses InModuleScope to test within the module context and allow mocks to work
 
 BeforeAll {
-    # Create stubs for Hyper-V cmdlets when they are not present (e.g. WSL, Linux)
-    # This allows Pester to mock these commands even without the Hyper-V module
-    if (-not (Get-Command Get-VM -ErrorAction SilentlyContinue)) {
-        function global:Get-VM { param($Name, $Id, $ErrorAction) }
-    }
-    if (-not (Get-Command New-VM -ErrorAction SilentlyContinue)) {
-        function global:New-VM { param($Name, $MemoryStartupBytes, $Generation, $VHDPath, $SwitchName) }
-    }
-    if (-not (Get-Command Remove-VM -ErrorAction SilentlyContinue)) {
-        function global:Remove-VM { param($Name, $Force, $ErrorAction) }
-    }
-    if (-not (Get-Command Start-VM -ErrorAction SilentlyContinue)) {
-        function global:Start-VM { param($Name, $ErrorAction) }
-    }
-    if (-not (Get-Command Stop-VM -ErrorAction SilentlyContinue)) {
-        function global:Stop-VM { param($Name, $Force, $ErrorAction) }
-    }
-    if (-not (Get-Command Restart-VM -ErrorAction SilentlyContinue)) {
-        function global:Restart-VM { param($Name, $Force, $ErrorAction) }
-    }
-    if (-not (Get-Command Suspend-VM -ErrorAction SilentlyContinue)) {
-        function global:Suspend-VM { param($Name, $ErrorAction) }
-    }
-    if (-not (Get-Command Resume-VM -ErrorAction SilentlyContinue)) {
-        function global:Resume-VM { param($Name, $ErrorAction) }
-    }
-    if (-not (Get-Command Set-VMProcessor -ErrorAction SilentlyContinue)) {
-        function global:Set-VMProcessor { param($VMName, $Count, $ErrorAction) }
-    }
-    if (-not (Get-Command Set-VMMemory -ErrorAction SilentlyContinue)) {
-        function global:Set-VMMemory { param($VMName, $StartupBytes, $ErrorAction) }
-    }
-    if (-not (Get-Command New-VHD -ErrorAction SilentlyContinue)) {
-        function global:New-VHD { param($Path, $SizeBytes, $Dynamic, $ErrorAction) }
-    }
-    if (-not (Get-Command Add-VMDvdDrive -ErrorAction SilentlyContinue)) {
-        function global:Add-VMDvdDrive { param($VMName, $Path, $ErrorAction) }
-    }
-    if (-not (Get-Command Get-VMDvdDrive -ErrorAction SilentlyContinue)) {
-        function global:Get-VMDvdDrive { param($VMName, $ErrorAction) }
-    }
-    if (-not (Get-Command Remove-VMDvdDrive -ErrorAction SilentlyContinue)) {
-        function global:Remove-VMDvdDrive { param($VMName, $ControllerNumber, $ControllerLocation, $ErrorAction) }
-    }
-    if (-not (Get-Command Get-VMNetworkAdapter -ErrorAction SilentlyContinue)) {
-        function global:Get-VMNetworkAdapter { param($VMName, $VM, $ErrorAction) }
-    }
-    if (-not (Get-Command Add-VMNetworkAdapter -ErrorAction SilentlyContinue)) {
-        function global:Add-VMNetworkAdapter { param($VMName, $VM, $SwitchName, $ErrorAction) }
-    }
-    if (-not (Get-Command Remove-VMNetworkAdapter -ErrorAction SilentlyContinue)) {
-        function global:Remove-VMNetworkAdapter { param($VMName, $VMNetworkAdapter, $Confirm, $ErrorAction) }
-    }
-    if (-not (Get-Command Get-VMSnapshot -ErrorAction SilentlyContinue)) {
-        function global:Get-VMSnapshot { param($VMName, $ErrorAction) }
-    }
-    if (-not (Get-Command Remove-VMSnapshot -ErrorAction SilentlyContinue)) {
-        function global:Remove-VMSnapshot { param($VMName, $ErrorAction) }
-    }
-    if (-not (Get-Command Get-VMHardDiskDrive -ErrorAction SilentlyContinue)) {
-        function global:Get-VMHardDiskDrive { param($VMName, $ErrorAction) }
-    }
-    if (-not (Get-Command Get-VMIntegrationService -ErrorAction SilentlyContinue)) {
-        function global:Get-VMIntegrationService { param($VMName, $Name, $ErrorAction) }
-    }
+    # Always define stubs so that Pester mocks apply (avoids type constraints of real Hyper-V cmdlets on Windows)
+    function global:Get-VM { param($Name, $Id, $ErrorAction) }
+    function global:New-VM { param($Name, $MemoryStartupBytes, $Generation, $VHDPath, $SwitchName) }
+    function global:Remove-VM { param($Name, $Force, $ErrorAction) }
+    function global:Start-VM { param($Name, $ErrorAction) }
+    function global:Stop-VM { param($Name, $Force, $ErrorAction) }
+    function global:Restart-VM { param($Name, $Force, $ErrorAction) }
+    function global:Suspend-VM { param($Name, $ErrorAction) }
+    function global:Resume-VM { param($Name, $ErrorAction) }
+    function global:Set-VMProcessor { param($VMName, $Count, $ErrorAction) }
+    function global:Set-VMMemory { param($VMName, $StartupBytes, $ErrorAction) }
+    function global:New-VHD { param($Path, $SizeBytes, $Dynamic, $ErrorAction) }
+    function global:Add-VMDvdDrive { param($VMName, $Path, $ErrorAction) }
+    function global:Get-VMDvdDrive { param($VMName, $ErrorAction) }
+    function global:Remove-VMDvdDrive { param($VMName, $ControllerNumber, $ControllerLocation, $ErrorAction) }
+    function global:Get-VMNetworkAdapter { param($VMName, $VM, $ErrorAction) }
+    function global:Add-VMNetworkAdapter { param($VMName, $VM, $Name, $SwitchName, $ErrorAction) }
+    function global:Remove-VMNetworkAdapter { param($VMName, $Name, $VMNetworkAdapter, $Confirm, $ErrorAction) }
+    function global:Connect-VMNetworkAdapter { param($VMName, $Name, $VMNetworkAdapter, $SwitchName, $ErrorAction) }
+    function global:Get-VMSnapshot { param($VMName, $ErrorAction) }
+    function global:Remove-VMSnapshot { param($VMName, $ErrorAction) }
+    function global:Get-VMHardDiskDrive { param($VMName, $ErrorAction) }
+    function global:Get-VMIntegrationService { param($VMName, $Name, $ErrorAction) }
 
     $modulePath = Join-Path $PSScriptRoot "../../src/modules/HvoVm/HvoVm.psd1"
     Import-Module $modulePath -Force
@@ -370,6 +328,9 @@ InModuleScope HvoVm {
     }
 
     Describe "Set-HvoVm" {
+        # Set-HvoVm uses -Id (GUID); network adapters are managed via Set-HvoVmNetworkAdapters (PUT /vms/:id/network-adapters).
+        $vmName = "stopped-vm"
+
         Context "When the VM does not exist" {
             It "Should return Updated = false with an error" {
                 $vmId = [guid]'00000000-0000-0000-0000-000000000001'
@@ -391,7 +352,6 @@ InModuleScope HvoVm {
                 Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
 
                 $result = Set-HvoVm -Id $vmId.ToString() -MemoryMB 2048
-
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $false
                 $result.Error | Should -Be "VM must be Off to update"
@@ -404,7 +364,6 @@ InModuleScope HvoVm {
                 $vmId = $script:testVmGuid
                 $mockVm = [PSCustomObject]@{ Id = $vmId; Name = "stopped-vm"; State = "Off"; MemoryStartup = 1GB; ProcessorCount = 2 }
                 Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -MockWith { return $null }
                 Mock Set-VMMemory -MockWith { }
 
                 $result = Set-HvoVm -Id $vmId.ToString() -MemoryMB 2048
@@ -420,7 +379,6 @@ InModuleScope HvoVm {
                 $vmId = $script:testVmGuid
                 $mockVm = [PSCustomObject]@{ Id = $vmId; Name = "stopped-vm"; State = "Off"; MemoryStartup = 1GB; ProcessorCount = 2 }
                 Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -MockWith { return $null }
                 Mock Set-VMProcessor -MockWith { }
 
                 $result = Set-HvoVm -Id $vmId.ToString() -Vcpu 4
@@ -437,47 +395,19 @@ InModuleScope HvoVm {
                 $memoryBytes = 1024 * 1MB
                 $mockVm = [PSCustomObject]@{ Id = $vmId; Name = "stopped-vm"; State = "Off"; MemoryStartup = $memoryBytes; ProcessorCount = 2 }
                 $mockVm | Add-Member -MemberType ScriptMethod -Name "ToString" -Value { return $this.State } -Force
-                $mockNic = [PSCustomObject]@{ SwitchName = "existing-switch" }
 
                 Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -MockWith { return $mockNic }
                 Mock Get-VMDvdDrive -MockWith { return $null }
                 Mock Set-VMMemory -MockWith { }
                 Mock Set-VMProcessor -MockWith { }
-                Mock Remove-VMNetworkAdapter -MockWith { }
-                Mock Add-VMNetworkAdapter -MockWith { }
-                Mock Remove-VMDvdDrive -MockWith { }
-                Mock Add-VMDvdDrive -MockWith { }
 
-                $result = Set-HvoVm -Id $vmId.ToString() -MemoryMB 1024 -Vcpu 2 -SwitchName "existing-switch"
+                $result = Set-HvoVm -Id $vmId.ToString() -MemoryMB 1024 -Vcpu 2
 
                 $result | Should -Not -BeNullOrEmpty
                 $result.Updated | Should -Be $false
                 $result.Unchanged | Should -Be $true
                 Should -Not -Invoke Set-VMMemory
                 Should -Not -Invoke Set-VMProcessor
-                Should -Not -Invoke Remove-VMNetworkAdapter
-                Should -Not -Invoke Add-VMNetworkAdapter
-            }
-
-            It "Should update the switch if different" {
-                $vmId = $script:testVmGuid
-                $mockVm = [PSCustomObject]@{ Id = $vmId; Name = "stopped-vm"; State = "Off"; MemoryStartup = 1GB; ProcessorCount = 2 }
-                $mockNic = [PSCustomObject]@{ SwitchName = "old-switch" }
-
-                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -MockWith { return $mockNic }
-                Mock Get-VMDvdDrive -MockWith { return $null }
-                Mock Remove-VMNetworkAdapter -MockWith { }
-                Mock Add-VMNetworkAdapter -MockWith { }
-
-                $result = Set-HvoVm -Id $vmId.ToString() -SwitchName "new-switch"
-
-                $result | Should -Not -BeNullOrEmpty
-                $result.Updated | Should -Be $true
-                # Remove-VMNetworkAdapter is called via pipeline, so no -VMName bound
-                Should -Invoke Remove-VMNetworkAdapter -Exactly -Times 1
-                Should -Invoke Add-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter { $VMName -eq "stopped-vm" -and $SwitchName -eq "new-switch" }
             }
 
             It "Should return an error if ISO file does not exist" {
@@ -485,7 +415,6 @@ InModuleScope HvoVm {
                 $isoPath = "/tmp/ISOs/nonexistent.iso"
                 $mockVm = [PSCustomObject]@{ Id = $vmId; Name = "stopped-vm"; State = "Off"; MemoryStartup = 1GB; ProcessorCount = 2 }
                 Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -MockWith { return $null }
                 Mock Test-Path -ParameterFilter { $Path -eq $isoPath } -MockWith { return $false }
 
                 $result = Set-HvoVm -Id $vmId.ToString() -IsoPath $isoPath
@@ -981,7 +910,7 @@ InModuleScope HvoVm {
                     MacAddress = "00155D012346"; Status = $mockStatus2
                 }
                 Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return @($mockAdapter1, $mockAdapter2) }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VMName } -MockWith { return @($mockAdapter1, $mockAdapter2) }
                 $result = Get-HvoVmNetworkAdapters -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Count | Should -Be 2
@@ -993,7 +922,7 @@ InModuleScope HvoVm {
                 $result[1].Name | Should -Be "Legacy Network Adapter"
                 $result[1].Type | Should -Be "Legacy"
                 Should -Invoke Get-VM -Exactly -Times 1 -ParameterFilter { $Id -eq $vmId }
-                Should -Invoke Get-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter { $null -ne $VM }
+                Should -Invoke Get-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter { $null -ne $VMName }
             }
 
             It "Should handle a single adapter (not an array)" {
@@ -1007,7 +936,7 @@ InModuleScope HvoVm {
                     MacAddress = "00155D012345"; Status = $mockStatus
                 }
                 Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return $mockAdapter }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VMName } -MockWith { return $mockAdapter }
                 $result = Get-HvoVmNetworkAdapters -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result.Count | Should -Be 1
@@ -1025,7 +954,7 @@ InModuleScope HvoVm {
                     MacAddress = "00155D012345"; Status = $mockStatus
                 }
                 Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return $mockAdapter }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VMName } -MockWith { return $mockAdapter }
                 $result = Get-HvoVmNetworkAdapters -Id $vmId.ToString()
                 $result | Should -Not -BeNullOrEmpty
                 $result[0].SwitchName | Should -BeNullOrEmpty
@@ -1037,7 +966,7 @@ InModuleScope HvoVm {
                 $vmId = $script:testVmGuid
                 $mockVm = [PSCustomObject]@{ Name = "vm-without-adapters" }
                 Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return $null }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VMName } -MockWith { return $null }
                 $result = Get-HvoVmNetworkAdapters -Id $vmId.ToString()
                 if ($null -ne $result) { $result.Count | Should -Be 0 }
                 Should -Invoke Get-VM -Exactly -Times 1
@@ -1050,7 +979,7 @@ InModuleScope HvoVm {
                 $vmId = $script:testVmGuid
                 $mockVm = [PSCustomObject]@{ Name = "vm-with-error" }
                 Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { throw "Access denied" }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VMName } -MockWith { throw "Access denied" }
                 { Get-HvoVmNetworkAdapters -Id $vmId.ToString() } | Should -Throw "Access denied"
             }
 
@@ -1058,7 +987,7 @@ InModuleScope HvoVm {
                 $vmId = $script:testVmGuid
                 $mockVm = [PSCustomObject]@{ Name = "vm-with-not-found-error" }
                 Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { throw "VM not found" }
+                Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VMName } -MockWith { throw "VM not found" }
                 $result = Get-HvoVmNetworkAdapters -Id $vmId.ToString()
                 $result | Should -BeNullOrEmpty
             }
@@ -1079,7 +1008,7 @@ InModuleScope HvoVm {
             $mockVm = [PSCustomObject]@{ Name = "vm1" }
             $mockAdapter = [PSCustomObject]@{ Id = [guid]::NewGuid(); Name = "NIC1" }
             Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-            Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return $mockAdapter }
+            Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VMName } -MockWith { return $mockAdapter }
             $result = Remove-HvoVmNetworkAdapter -VMId $vmId.ToString() -AdapterId "00000000-0000-0000-0000-000000000000"
             $result | Should -Be $false
         }
@@ -1090,11 +1019,86 @@ InModuleScope HvoVm {
             $mockVm = [PSCustomObject]@{ Name = "vm1" }
             $mockAdapter = [PSCustomObject]@{ Id = $adapterId; Name = "NIC1" }
             Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
-            Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VM } -MockWith { return $mockAdapter }
+            Mock Get-VMNetworkAdapter -ParameterFilter { $null -ne $VMName } -MockWith { return $mockAdapter }
             Mock Remove-VMNetworkAdapter -MockWith { }
             $result = Remove-HvoVmNetworkAdapter -VMId $vmId.ToString() -AdapterId $adapterId.ToString()
             $result | Should -Be $true
-            Should -Invoke Remove-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter { $null -ne $VMNetworkAdapter }
+            Should -Invoke Remove-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter { $null -ne $VMName -and $null -ne $Name }
+        }
+    }
+
+    Describe "Set-HvoVmNetworkAdapters" {
+        Context "When the VM does not exist" {
+            It "Should return Updated = false with VM not found" {
+                $vmId = [Guid]::NewGuid()
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $null }
+
+                $result = Set-HvoVmNetworkAdapters -Id $vmId -NetworkAdapters @()
+
+                $result | Should -Not -BeNullOrEmpty
+                $result.Updated | Should -Be $false
+                $result.Error | Should -Be "VM not found"
+            }
+        }
+
+        Context "When the VM exists" {
+            It "Should return Unchanged when desired list matches current (empty)" {
+                $vmId = [Guid]::NewGuid()
+                $mockVm = [PSCustomObject]@{
+                    Name = "test-vm"
+                    Id   = $vmId
+                }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -MockWith { return @() }
+                Mock Remove-VMNetworkAdapter -MockWith { }
+                Mock Add-VMNetworkAdapter -MockWith { }
+
+                $result = Set-HvoVmNetworkAdapters -Id $vmId -NetworkAdapters @()
+
+                $result.Updated | Should -Be $false
+                $result.Unchanged | Should -Be $true
+                Should -Not -Invoke Remove-VMNetworkAdapter
+                Should -Not -Invoke Add-VMNetworkAdapter
+            }
+
+            It "Should remove adapters not in desired list" {
+                $vmId = [Guid]::NewGuid()
+                $mockVm = [PSCustomObject]@{
+                    Name = "test-vm"
+                    Id   = $vmId
+                }
+                $mockNic = [PSCustomObject]@{
+                    Name       = "OldAdapter"
+                    SwitchName = "OldSwitch"
+                }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -MockWith { return @($mockNic) }
+                Mock Remove-VMNetworkAdapter -MockWith { }
+                Mock Add-VMNetworkAdapter -MockWith { }
+
+                $result = Set-HvoVmNetworkAdapters -Id $vmId -NetworkAdapters @(
+                    @{ name = "Ethernet"; switchName = "LAN" }
+                )
+
+                $result.Updated | Should -Be $true
+                Should -Invoke Remove-VMNetworkAdapter -Exactly -Times 1
+                Should -Invoke Add-VMNetworkAdapter -Exactly -Times 1 -ParameterFilter {
+                    $VMName -eq "test-vm" -and $Name -eq "Ethernet" -and $SwitchName -eq "LAN"
+                }
+            }
+
+            It "Should throw when adapter item missing name or switchName" {
+                $vmId = [Guid]::NewGuid()
+                $mockVm = [PSCustomObject]@{
+                    Name = "test-vm"
+                    Id   = $vmId
+                }
+                Mock Get-VM -ParameterFilter { $Id -eq $vmId } -MockWith { return $mockVm }
+                Mock Get-VMNetworkAdapter -MockWith { return @() }
+
+                { Set-HvoVmNetworkAdapters -Id $vmId -NetworkAdapters @(@{ name = "n" }) } | Should -Throw "*name*switchName*"
+                { Set-HvoVmNetworkAdapters -Id $vmId -NetworkAdapters @(@{ switchName = "s" }) } | Should -Throw "*name*switchName*"
+            }
         }
     }
 }


### PR DESCRIPTION
## fix(api): declarative network adapter model (issue #25)

### Description

This change separates VM configuration from network adapter management: `PUT /vms/:id` only updates VM settings, and a new endpoint `PUT /vms/:id/network-adapters` handles declarative reconciliation of network adapters (hot-add/hot-remove). The PowerShell module exposes `Set-HvoVmNetworkAdapters` for that endpoint and `Set-HvoVm` no longer accepts or applies `NetworkAdapters`. OpenAPI and api-reference are updated, and tests cover both `Set-HvoVm` (by Id) and `Set-HvoVmNetworkAdapters`.

Refs #25

---

### Type of change

- [x] Fix (bug fix)
- [ ] Feature (new functionality)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Chore / maintenance

---

### Context

**Why is this change needed?**  
The API mixed declarative and imperative behaviour for network adapters: updating a VM could both change VM config and implicitly add/remove adapters, which was confusing and hard to use correctly.

**What problem does it solve?**  
It clarifies responsibilities: VM config vs. network adapter state. Users can update VM properties without touching adapters, and manage adapters explicitly via a dedicated endpoint with predictable declarative reconciliation (hot-add/hot-remove).

---

### Changes

- **API**
  - `PUT /vms/:id` no longer accepts or applies `networkAdapters`; it only updates VM configuration.
  - New `PUT /vms/:id/network-adapters` for declarative reconciliation of network adapters (hot-add/hot-remove).
- **PowerShell**
  - `Set-HvoVmNetworkAdapters` added in `HvoVm.psm1` to call the new endpoint.
  - `Set-HvoVm` no longer handles `NetworkAdapters`.
- **Docs & specs**
  - OpenAPI spec and api-reference updated for the new endpoint and VM payload.
- **Tests**
  - Tests added/updated for `Set-HvoVm` (by Id) and `Set-HvoVmNetworkAdapters`.

---

### Tests

- Manual checks: VM update without adapters; adapter reconciliation via new endpoint.
- Existing behaviour: VM CRUD and other endpoints still work as before.
- Documentation: OpenAPI and api-reference reviewed for consistency with implementation.

---

### Breaking changes

- **This PR introduces breaking changes.**

**What breaks:**  
- `PUT /vms/:id` no longer accepts a `networkAdapters` field; that field is ignored if sent.
- Clients that relied on updating network adapters via `PUT /vms/:id` must switch to `PUT /vms/:id/network-adapters`.

**How to adapt:**  
Use `PUT /vms/:id` only for VM configuration. Use `PUT /vms/:id/network-adapters` with the desired adapter list for declarative adapter management. In PowerShell, use `Set-HvoVmNetworkAdapters` for adapters and `Set-HvoVm` for VM properties.

---

### Checklist

- [x] Code follows project standards  
- [x] Code comments added where necessary  
- [x] Documentation updated (README and/or docs)  
- [x] No secrets or sensitive information committed  
- [x] No new external dependencies introduced  
